### PR TITLE
Output bandpass calibrations to CASA bcal tables

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.4-
 CasaCore
 JSON
-NPZ


### PR DESCRIPTION
Previously bandpass calibrations were written to disk as numpy arrays.
The main reason for this change is interoperability with other pieces of
software.

This removes TTCal's dependence on NPZ.
