### PR TITLE
Propogate flags from data to gains and gains to data

### DIFF
--- a/src/applycal.jl
+++ b/src/applycal.jl
@@ -17,50 +17,71 @@ function applycal!(ms::Table,
                    gains::Array{Complex64};
                    apply_to_corrected::Bool = false,
                    force_imaging_columns::Bool = false)
+    gain_flags = zeros(Bool,size(gains))
+    applycal!(gains,gain_flags,
+              apply_to_corrected=apply_to_corrected,
+              force_imaging_columns=force_imaging_columns)
+end
+                   
+
+function applycal!(ms::Table,
+                   gains::Array{Complex64},
+                   gain_flags::Array{Bool};
+                   apply_to_corrected::Bool = false,
+                   force_imaging_columns::Bool = false)
     ant1,ant2 = ants(ms)
     data = apply_to_corrected? ms["CORRECTED_DATA"] : ms["DATA"]
-    applycal!(data,gains,ant1,ant2)
+    data_flags = ms["FLAG"]
+    applycal!(data,data_flags,gains,gain_flags,ant1,ant2)
     if force_imaging_columns || Tables.checkColumnExists(ms,"CORRECTED_DATA")
         ms["CORRECTED_DATA"] = data
     else
         ms["DATA"] = data
     end
+    ms["FLAG"] = data_flags
     data
 end
 
 function applycal!(data::Array{Complex64,3},
+                   data_flags::Array{Bool,3},
                    gains::Array{Complex64,3},
+                   gain_flags::Array{Bool,3},
                    ant1::Vector{Int32},
                    ant2::Vector{Int32})
     # gains are from bandpass(...)
     Nbase = length(ant1)
     Nfreq = size(gains,3)
     for α = 1:Nbase, β = 1:Nfreq
-        data[1,β,α] = (gains[ant1[α],1,β]*conj(gains[ant2[α],1,β]))\data[1,β,α]
-        data[2,β,α] = (gains[ant1[α],1,β]*conj(gains[ant2[α],2,β]))\data[2,β,α] # this one could be
-        data[3,β,α] = (gains[ant1[α],2,β]*conj(gains[ant2[α],1,β]))\data[3,β,α] # swapped with this one
-        data[4,β,α] = (gains[ant1[α],2,β]*conj(gains[ant2[α],2,β]))\data[4,β,α]
+        if gain_flags[ant1[α],1,β] || gain_flags[ant1[α],2,β] || gain_flags[ant2[α],1,β] || gain_flags[ant2[α],2,β]
+            data_flags[:,β,α] = true
+        else
+            data[1,β,α] = (gains[ant1[α],1,β]*conj(gains[ant2[α],1,β]))\data[1,β,α]
+            data[2,β,α] = (gains[ant1[α],1,β]*conj(gains[ant2[α],2,β]))\data[2,β,α] # this one could be
+            data[3,β,α] = (gains[ant1[α],2,β]*conj(gains[ant2[α],1,β]))\data[3,β,α] # swapped with this one
+            data[4,β,α] = (gains[ant1[α],2,β]*conj(gains[ant2[α],2,β]))\data[4,β,α]
+        end
     end
 end
 
-function applycal!(data::Array{Complex64,3},
-                   gains::Array{Complex64,4},
-                   ant1::Vector{Int32},
-                   ant2::Vector{Int32})
-    # gains are from polcal(...)
-    # TODO: speed this up (it is very slow)
-    Nbase = length(ant1)
-    Nfreq = size(gains,4)
-    for α = 1:Nbase, β = 1:Nfreq
-        V = [data[1,β,α] data[3,β,α]
-             data[2,β,α] data[4,β,α]]
-        G1 = gains[:,:,ant1[α],β]
-        G2 = gains[:,:,ant2[α],β]
-        V = G2'\(V/G1)
-        data[1,β,α] = V[1,1]
-        data[2,β,α] = V[2,1]
-        data[3,β,α] = V[1,2]
-        data[4,β,α] = V[2,2]
-    end
-end
+# TODO: fix this to use gain flags correctly
+#function applycal!(data::Array{Complex64,3},
+#                   gains::Array{Complex64,4},
+#                   ant1::Vector{Int32},
+#                   ant2::Vector{Int32})
+#    # gains are from polcal(...)
+#    # TODO: speed this up (it is very slow)
+#    Nbase = length(ant1)
+#    Nfreq = size(gains,4)
+#    for α = 1:Nbase, β = 1:Nfreq
+#        V = [data[1,β,α] data[3,β,α]
+#             data[2,β,α] data[4,β,α]]
+#        G1 = gains[:,:,ant1[α],β]
+#        G2 = gains[:,:,ant2[α],β]
+#        V = G2'\(V/G1)
+#        data[1,β,α] = V[1,1]
+#        data[2,β,α] = V[2,1]
+#        data[3,β,α] = V[1,2]
+#        data[4,β,α] = V[2,2]
+#    end
+#end
 

--- a/src/bandpass.jl
+++ b/src/bandpass.jl
@@ -171,6 +171,7 @@ function bandpass_onechannel!(gains, gain_flags,
 
     # 7. Flag the antennas with no unflagged data.
     bad_ants = squeeze(all(square_flags,1),1)
+    gains[bad_ants] = 1.0
     gain_flags[bad_ants] = true
 
     nothing


### PR DESCRIPTION
This and #9 allow me to output `bcal` tables that `dada2ms` can use to flag and calibrate the data in one pass. One of the largest bottlenecks is reading the data from disk, so the fewer times we have to read data the better.

This PR does comment out `applycal` for my polarized calibration routine, but that needed some love anyway.
