### PR TITLE
Calibrating from the MODEL_DATA column and diagnosing bad antennas

### DIFF
--- a/src/TTCal.jl
+++ b/src/TTCal.jl
@@ -50,12 +50,12 @@ include("applycal.jl")
 
 function run_bandpass(args)
     ms = Table(ascii(args["--input"]))
-    sources = readsources(args["--sources"])
+    sources = haskey(args,"--sources")? readsources(args["--sources"]) : Source[]
     maxiter = haskey(args,"--maxiter")? args["--maxiter"] : 20
     tol = haskey(args,"--tolerance")? args["--tolerance"] : 1e-4
     criteria = StoppingCriteria(maxiter,tol)
     force_imaging_columns = haskey(args,"--force-imaging")
-    model_already_present = haskey(args,"--model-present")
+    model_already_present = !haskey(args,"--sources")
     gains,gain_flags = bandpass(ms,sources,criteria,
                                 force_imaging_columns=force_imaging_columns,
                                 model_already_present=model_already_present)
@@ -65,11 +65,15 @@ end
 
 function run_polcal(args)
     ms = Table(ascii(args["--input"]))
-    sources = readsources(args["--sources"])
+    sources = haskey(args,"--sources")? readsources(args["--sources"]) : Source[]
     maxiter = haskey(args,"--maxiter")? args["--maxiter"] : 20
     tol = haskey(args,"--tolerance")? args["--tolerance"] : 1e-4
     criteria = StoppingCriteria(maxiter,tol)
-    gains,gain_flags = polcal(ms,sources,criteria)
+    force_imaging_columns = haskey(args,"--force-imaging")
+    model_already_present = !haskey(args,"--sources")
+    gains,gain_flags = polcal(ms,sources,criteria,
+                              force_imaging_columns=force_imaging_columns,
+                              model_already_present=model_already_present)
     write_gains(args["--output"],gains,gain_flags)
     gains, gain_flags
 end

--- a/src/TTCal.jl
+++ b/src/TTCal.jl
@@ -47,6 +47,7 @@ include("io.jl")
 include("bandpass.jl")
 include("polcal.jl")
 include("applycal.jl")
+include("diagnose.jl")
 
 function run_bandpass(args)
     ms = Table(ascii(args["--input"]))
@@ -89,6 +90,10 @@ function run_applycal(args)
                   apply_to_corrected=apply_to_corrected)
     end
     nothing
+end
+
+function run_diagnose(args)
+    diagnose(args["--calibration"])
 end
 
 end

--- a/src/TTCal.jl
+++ b/src/TTCal.jl
@@ -54,7 +54,11 @@ function run_bandpass(args)
     maxiter = haskey(args,"--maxiter")? args["--maxiter"] : 20
     tol = haskey(args,"--tolerance")? args["--tolerance"] : 1e-4
     criteria = StoppingCriteria(maxiter,tol)
-    gains,gain_flags = bandpass(ms,sources,criteria)
+    force_imaging_columns = haskey(args,"--force-imaging")
+    model_already_present = haskey(args,"--model-present")
+    gains,gain_flags = bandpass(ms,sources,criteria,
+                                force_imaging_columns=force_imaging_columns,
+                                model_already_present=model_already_present)
     write_gains(args["--output"],gains,gain_flags)
     gains, gain_flags
 end

--- a/src/bandpass.jl
+++ b/src/bandpass.jl
@@ -23,6 +23,7 @@ function bandpass(ms::Table,
                   sources::Vector{PointSource},
                   criteria::StoppingCriteria;
                   force_imaging_columns::Bool = false,
+                  model_already_present::Bool = false,
                   reference_antenna::Int = 1)
     frame = reference_frame(ms)
     u,v,w = uvw(ms)
@@ -38,7 +39,7 @@ function bandpass(ms::Table,
     gain_flags = zeros(Bool,Nant,2,Nfreq)
 
     data  = ms["DATA"]
-    model = genvis(frame,sources,u,v,w,ν)
+    model = model_already_present? ms["MODEL_DATA"] : genvis(frame,sources,u,v,w,ν)
     data_flags = ms["FLAG"]
     row_flags  = ms["FLAG_ROW"]
     for α = 1:length(row_flags)

--- a/src/diagnose.jl
+++ b/src/diagnose.jl
@@ -1,0 +1,87 @@
+# Copyright (c) 2015 Michael Eastwood
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+@doc """
+Diagnose a calibration by looking for bad antennas.
+
+The algorithms employed here to identify misbehaving antennas are
+tailored for the OVRO LWA and may not be ideal for other interferometers.
+""" ->
+function diagnose(filename)
+    gains,gain_flags = read_gains(filename)
+    diagnose(gains,gain_flags)
+end
+
+function diagnose(gains::Array{Complex64,3},
+                  gain_flags::Array{Bool,3};
+                  Nprint=20)
+    Nant = size(gains,1)
+
+    # Calculate the correlation function of the antenna gains
+    xcorr = zeros(Nant,Nant)
+    ycorr = zeros(Nant,Nant)
+    for ant1 = 1:Nant, ant2 = 1:Nant
+        x1 = abs(slice(gains,ant1,1,:))
+        x2 = abs(slice(gains,ant2,1,:))
+        y1 = abs(slice(gains,ant1,2,:))
+        y2 = abs(slice(gains,ant2,2,:))
+        σx1 = mean((x1-mean(x1)) .* conj(x1-mean(x1)))
+        σx2 = mean((x2-mean(x2)) .* conj(x2-mean(x2)))
+        σy1 = mean((y1-mean(y1)) .* conj(y1-mean(y1)))
+        σy2 = mean((y2-mean(y2)) .* conj(y2-mean(y2)))
+        σx1x2 = mean((x1-mean(x1)) .* conj(x2-mean(x2)))
+        σy1y2 = mean((y1-mean(y1)) .* conj(y2-mean(y2)))
+        xcorr[ant1,ant2] = σx1x2/sqrt(σx1*σx2)
+        ycorr[ant1,ant2] = σy1y2/sqrt(σy1*σy2)
+    end
+    xcorr[isnan(xcorr)] = 0.0
+    ycorr[isnan(ycorr)] = 0.0
+
+    # Factor the correlation matriices
+    λ,v = eigs(xcorr,nev=1,which=:LM)
+    x = sqrt(λ[1])*v[:,1]
+    λ,v = eigs(ycorr,nev=1,which=:LM)
+    y = sqrt(λ[1])*v[:,1]
+
+    # Try to make all the good antennas positive
+    # (this assumes that >50% of the antennas are good)
+    x *= sign(median(x))
+    y *= sign(median(y))
+    scores = [x;y]
+
+    # Print the worst antennas
+    println("Consider flagging one or more of the following antennas:")
+    println(" Antenna | Pol | Score ")
+    println("---------|-----|-------")
+    badants = sortperm(scores)
+    N = 1
+    idx = 1
+    while N < Nprint
+        ant = badants[idx]
+        pol = 1
+        if ant > Nant
+            ant -= Nant
+            pol = 2
+        end
+        if all(gain_flags[ant,pol,:])
+            idx += 1
+            continue
+        end
+        @printf("   %3d   |  %s  | %+4.2f \n",ant,pol == 1?"a":"b",scores[badants[idx]])
+        N += 1
+        idx += 1
+    end
+end
+

--- a/src/polcal.jl
+++ b/src/polcal.jl
@@ -20,6 +20,7 @@ function polcal(ms::Table,
                 sources::Vector{PointSource},
                 criteria::StoppingCriteria;
                 force_imaging_columns::Bool = false,
+                model_already_present::Bool = false,
                 reference_antenna::Int = 1)
     frame = reference_frame(ms)
     u,v,w = uvw(ms)
@@ -35,7 +36,7 @@ function polcal(ms::Table,
     gain_flags = zeros(Bool,Nant,Nfreq)
 
     data  = Tables.checkColumnExists(ms,"CORRECTED_DATA")? ms["CORRECTED_DATA"] : ms["DATA"]
-    model = genvis(frame,sources,u,v,w,ν)
+    model = model_already_present? ms["MODEL_DATA"] : genvis(frame,sources,u,v,w,ν)
     data_flags = ms["FLAG"]
     row_flags  = ms["FLAG_ROW"]
     for α = 1:length(row_flags)

--- a/src/ttcal.jl
+++ b/src/ttcal.jl
@@ -33,67 +33,60 @@ push!(CLI.commands,Command("applycal","Apply a calibration."))
 
 CLI.options["bandpass"] = [
     Option("--input","""
-        The measurement set used to solve for a bandpass calibration.""",
-        UTF8String,true,1,1),
+        The measurement set used to solve for the calibration.""",
+        T=UTF8String,
+        required=true,
+        min=1,
+        max=1),
     Option("--output","""
-        The output file to which the bandpass calibration will be written.
+        The output file to which the calibration will be written.
         This output file will be overwritten if it already exists.""",
-        UTF8String,true,1,1),
+        T=UTF8String,
+        required=true,
+        min=1,
+        max=1),
     Option("--sources","""
-        A JSON file describing the sources to be used for the sky model.""",
-        UTF8String,true,1,1),
+        A JSON file describing the sources to be used for the sky model.
+        If this option is not used, TTCal assumes there is a MODEL_DATA
+        column populated with model visibilities.""",
+        T=UTF8String,
+        min=1,
+        max=1),
     Option("--maxiter","""
         Set the maximum number of Stefcal iterations to take on each
         frequency channel.""",
-        Int,false,1,1),
+        T=Int,
+        min=1,
+        max=1),
     Option("--tolerance","""
         Set the relative tolerance used to determine convergence.""",
-        Float64,false,1,1),
+        T=Float64,
+        min=1,
+        max=1),
     Option("--force-imaging","""
         Create and use the MODEL_DATA and CORRECTED_DATA columns even if
-        they do not already exist in the measurement set.""",
-        Nothing,false,0,0),
-    Option("--model-present","""
-        Use this flag to indicate that there is already a set of model
-        visibilities present in the MODEL_DATA column of the measurement
-        set. TTCal will use these model visibilities in place of the
-        source model specified by the --sources flag (for now --sources
-        is still mandatory even though it is effectively ignored).""",
-        Nothing,false,0,0)]
-CLI.options["polcal"] = [
-    Option("--input","""
-        The measurement set used to solve for a polarization calibration.""",
-        UTF8String,true,1,1),
-    Option("--output","""
-        The output file to which the polarization calibration will be written.
-        This output file will be overwritten if it already exists.""",
-        UTF8String,true,1,1),
-    Option("--sources","""
-        A JSON file describing the sources to be used for the sky model.""",
-        UTF8String,true,1,1),
-    Option("--maxiter","""
-        Set the maximum number of Stefcal iterations to take on each
-        frequency channel.""",
-        Int,false,1,1),
-    Option("--tolerance","""
-        Set the relative tolerance used to determine convergence.""",
-        Float64,false,1,1)]
+        they do not already exist in the measurement set.""")]
+CLI.options["polcal"] = CLI.options["bandpass"]
 CLI.options["applycal"] = [
     Option("--input","""
         The list of measurement sets that the calibration will be applied to.""",
-        UTF8String,true,1,Inf),
+        T=UTF8String,
+        required=true,
+        min=1,
+        max=Inf),
     Option("--calibration","""
         The file containing the calibration solution.""",
-        UTF8String,true,1,1),
+        T=UTF8String,
+        required=true,
+        min=1,
+        max=1),
     Option("--force-imaging","""
         Write the calibrated visibilities to the CORRECTED_DATA column
         regardless of whether or not the measurement set already has
-        this column (it will be created if it doesn't exist).""",
-        Nothing,false,0,0),
+        this column (it will be created if it doesn't exist)."""),
     Option("--corrected","""
         Apply the calibration to the CORRECTED_DATA column instead
-        of the DATA column.""",
-        Nothing,false,0,0)]
+        of the DATA column.""")]
 
 import TTCal
 

--- a/src/ttcal.jl
+++ b/src/ttcal.jl
@@ -48,7 +48,18 @@ CLI.options["bandpass"] = [
         Int,false,1,1),
     Option("--tolerance","""
         Set the relative tolerance used to determine convergence.""",
-        Float64,false,1,1)]
+        Float64,false,1,1),
+    Option("--force-imaging","""
+        Create and use the MODEL_DATA and CORRECTED_DATA columns even if
+        they do not already exist in the measurement set.""",
+        Nothing,false,0,0),
+    Option("--model-present","""
+        Use this flag to indicate that there is already a set of model
+        visibilities present in the MODEL_DATA column of the measurement
+        set. TTCal will use these model visibilities in place of the
+        source model specified by the --sources flag (for now --sources
+        is still mandatory even though it is effectively ignored).""",
+        Nothing,false,0,0)]
 CLI.options["polcal"] = [
     Option("--input","""
         The measurement set used to solve for a polarization calibration.""",

--- a/src/ttcal.jl
+++ b/src/ttcal.jl
@@ -30,6 +30,7 @@ CLI.print_banner()
 push!(CLI.commands,Command("bandpass","Solve for a bandpass calibration."))
 push!(CLI.commands,Command("polcal","Solve for a polarization calibration."))
 push!(CLI.commands,Command("applycal","Apply a calibration."))
+push!(CLI.commands,Command("diagnose","Diagnose a poor calibration."))
 
 CLI.options["bandpass"] = [
     Option("--input","""
@@ -101,6 +102,8 @@ try
         TTCal.run_polcal(args)
     elseif command == "applycal"
         TTCal.run_applycal(args)
+    elseif command == "diagnose"
+        TTCal.run_diagnose(args)
     end
 catch err
     if isa(err, ErrorException)


### PR DESCRIPTION
- You can now calibrate without specifying a source model, but TTCal will then assume that there exists a set of model visibilities in the MODEL_DATA column.
- A new `diagnose` function has been added to help identify bad antennas. This fixes #12.
