### PR TITLE
implement amplitude-only calibration

### DIFF
--- a/src/TTCal.jl
+++ b/src/TTCal.jl
@@ -25,7 +25,7 @@ export getspec
 export fitvis
 export subsrc!
 
-export gaincal, polcal
+export ampcal, gaincal, polcal
 export applycal!, corrupt!
 export peel!
 

--- a/src/ampcal.jl
+++ b/src/ampcal.jl
@@ -1,0 +1,162 @@
+# Copyright (c) 2015 Michael Eastwood
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+immutable AmplitudeCalibration <: Calibration
+    amplitudes::Array{Float64,3}
+    flags::Array{Bool,3}
+end
+
+function AmplitudeCalibration(Nant,Nfreq)
+    amplitudes = ones(Float64,Nant,Nfreq,2)
+    flags = zeros(Bool,Nant,Nfreq,2)
+    AmplitudeCalibration(amplitudes,flags)
+end
+
+Nant(g::AmplitudeCalibration) = size(g.amplitudes,1)
+Nfreq(g::AmplitudeCalibration) = size(g.amplitudes,2)
+
+function invert(cal::AmplitudeCalibration)
+    output = AmplitudeCalibration(Nant(cal),Nfreq(cal))
+    for i in eachindex(cal.amplitudes)
+        output.amplitudes[i] = inv(cal.amplitudes[i])
+    end
+    output
+end
+
+function ampcal(ms::Table,
+                sources::Vector{PointSource};
+                maxiter::Int = 30,
+                tolerance::Float64 = 1e-3,
+                force_imaging_columns::Bool = false)
+    phase_dir = MeasurementSets.phase_direction(ms)
+    u,v,w = MeasurementSets.uvw(ms)
+    ν = MeasurementSets.frequency(ms)
+    ant1,ant2 = MeasurementSets.antennas(ms)
+
+    frame = ReferenceFrame()
+    set!(frame,MeasurementSets.position(ms))
+    set!(frame,MeasurementSets.time(ms))
+    sources = filter(source -> isabovehorizon(frame,source),sources)
+
+    Nant  = numrows(Table(ms[kw"ANTENNA"]))
+    Nfreq = length(ν)
+    calibration = AmplitudeCalibration(Nant,Nfreq)
+
+    data  = ms["DATA"]
+    model = genvis(frame,phase_dir,sources,u,v,w,ν)
+    flags = MeasurementSets.flags(ms)
+
+    if force_imaging_columns || Tables.checkColumnExists(ms,"MODEL_DATA")
+        ms["MODEL_DATA"] = model
+    end
+
+    ampcal!(calibration,data,model,flags,
+            ant1,ant2,maxiter,tolerance)
+    calibration
+end
+
+function ampcal!(calibration,data,model,flags,
+                 ant1,ant2,maxiter,tolerance)
+    for β = 1:Nfreq(calibration)
+        # Calibrate the X polarization
+        ampcal_onechannel!(slice(calibration.amplitudes,:,β,1),
+                           slice(calibration.flags,:,β,1),
+                           slice(data, 1,β,:),
+                           slice(model,1,β,:),
+                           slice(flags,1,β,:),
+                           ant1, ant2,
+                           maxiter, tolerance)
+        # Calibrate the Y polarization
+        ampcal_onechannel!(slice(calibration.amplitudes,:,β,2),
+                           slice(calibration.flags,:,β,2),
+                           slice(data, 4,β,:),
+                           slice(model,4,β,:),
+                           slice(flags,4,β,:),
+                           ant1, ant2,
+                           maxiter, tolerance)
+    end
+end
+
+function ampcal_onechannel!(amplitudes, amplitude_flags,
+                            data, model, data_flags,
+                            ant1, ant2,
+                            maxiter, tolerance)
+    # If the entire channel is flagged, don't bother calibrating.
+    if all(data_flags)
+        amplitude_flags[:] = true
+        return
+    end
+
+    square_data  = ampcal_makesquare( data,data_flags,ant1,ant2)
+    square_model = ampcal_makesquare(model,data_flags,ant1,ant2)
+    best_amplitudes = ones(Float64,length(amplitudes))
+    converged = @iterate(AmpCalStep(),RK4,maxiter,tolerance,
+                         best_amplitudes,square_data,square_model)
+
+    # Flag the entire channel if the solution did not converge.
+    if !converged
+        amplitude_flags[:] = true
+        return
+    end
+
+    # Output
+    for ant = 1:length(amplitudes)
+        amplitudes[ant] = best_amplitudes[ant]
+    end
+    nothing
+end
+
+function ampcal_makesquare(data,flags,ant1,ant2)
+    gaincal_makesquare(data,flags,ant1,ant2)
+end
+
+function ampcal_step(input,data,model)
+    Nant = length(input)
+    step = zeros(Float64,Nant)
+    @inbounds for j = 1:Nant
+        numerator   = zero(Float64)
+        denominator = zero(Float64)
+        for i = 1:Nant
+            GM = input[i]*model[i,j]
+            numerator = numerator + abs(real(GM*data[i,j]))
+            denominator = denominator + abs2(GM)
+        end
+        ok = abs(denominator) > eps(Float64)
+        step[j] = ifelse(ok,conj(numerator/denominator) - input[j],0)
+    end
+    step
+end
+
+immutable AmpCalStep <: StepFunction end
+call(::AmpCalStep,g,V,M) = ampcal_step(g,V,M)
+
+function corrupt!(data::Array{Complex64,3},
+                  flags::Array{Bool,3},
+                  cal::AmplitudeCalibration,
+                  ant1,ant2)
+    Nbase = length(ant1)
+    for α = 1:Nbase, β = 1:Nfreq(cal)
+        if (cal.flags[ant1[α],β,1] || cal.flags[ant1[α],β,2]
+                                   || cal.flags[ant2[α],β,1]
+                                   || cal.flags[ant2[α],β,2])
+            flags[:,β,α] = true
+        end
+        data[1,β,α] = cal.amplitudes[ant1[α],β,1]*cal.amplitudes[ant2[α],β,1]*data[1,β,α]
+        data[2,β,α] = cal.amplitudes[ant1[α],β,1]*cal.amplitudes[ant2[α],β,2]*data[2,β,α]
+        data[3,β,α] = cal.amplitudes[ant1[α],β,2]*cal.amplitudes[ant2[α],β,1]*data[3,β,α]
+        data[4,β,α] = cal.amplitudes[ant1[α],β,2]*cal.amplitudes[ant2[α],β,2]*data[4,β,α]
+    end
+end
+

--- a/src/calibration.jl
+++ b/src/calibration.jl
@@ -59,6 +59,7 @@ import JLD
 write(filename,calibration::Calibration) = JLD.save(filename,"cal",calibration)
 read(filename) = JLD.load(filename,"cal")
 
+include("ampcal.jl")
 include("gaincal.jl")
 include("polcal.jl")
 

--- a/src/gaincal.jl
+++ b/src/gaincal.jl
@@ -204,8 +204,8 @@ function gaincal_step(input,data,model)
     Nant = length(input)
     step = zeros(Complex64,Nant)
     @inbounds for j = 1:Nant
-        numerator   = Complex64(0)
-        denominator = Complex64(0)
+        numerator   = zero(Complex64)
+        denominator = zero(Complex64)
         for i = 1:Nant
             GM = input[i]*model[i,j]
             numerator = numerator + GM'*data[i,j]

--- a/src/sourcemodel.jl
+++ b/src/sourcemodel.jl
@@ -55,16 +55,16 @@ end
 
 for param in (:I,:Q,:U,:V)
     func = symbol("stokes",param)
-    @eval function $func{T<:FloatingPoint}(source::PointSource,frequency::T)
+    @eval function $func{T<:AbstractFloat}(source::PointSource,frequency::T)
         powerlaw(source.$param,source.index,source.reffreq,frequency)
     end
-    @eval function $func{T<:FloatingPoint}(source::PointSource,frequencies::Vector{T})
+    @eval function $func{T<:AbstractFloat}(source::PointSource,frequencies::Vector{T})
         [$func(source,frequency) for frequency in frequencies]
     end
 end
 
-flux{T<:FloatingPoint}(source::PointSource,frequency::T) = stokesI(source,frequency)
-flux{T<:FloatingPoint}(source::PointSource,frequencies::Vector{T}) = stokesI(source,frequencies)
+flux{T<:AbstractFloat}(source::PointSource,frequency::T) = stokesI(source,frequency)
+flux{T<:AbstractFloat}(source::PointSource,frequencies::Vector{T}) = stokesI(source,frequencies)
 
 ################################################################################
 # Position


### PR DESCRIPTION
Related to #28 

This implements amplitude-only calibration.

Amplitude-only calibration is very useful when trying to calibrate off a single point source at a time while there is unmodeled flux in the sky. This is exactly the situation we run into while trying to peel sources. Essentially, if you are trying to calibrate on a point source, but there exists a second source of similar flux elsewhere on the sky, a full complex gain calibration may move the second source to the location of the first source. This is impossible with an amplitude-only calibration.

However, it is important to remember that the amplitude-only calibration will be systematically offset from a full complex gain calibration. This is due to the fact that the amplitude-only calibration is unable to introduce small phases that correct for positional errors.
