### PR TITLE
fix several bugs and add a function for writing ds9 region files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: julia
+os:
+    - linux
 julia:
     - 0.4
     - nightly

--- a/doc/gendoc.jl
+++ b/doc/gendoc.jl
@@ -9,8 +9,8 @@ import Base.Docs: FuncDoc, TypeDoc
 
 cd(dirname(@__FILE__))
 
-exports = names(TTCal)
-meta    = Docs.meta(TTCal)
+exports = @eval names($module_name)
+meta    = @eval Docs.meta($module_name)
 @show exports
 
 # Get the plain text docs corresponding to each type and function.

--- a/src/ampcal.jl
+++ b/src/ampcal.jl
@@ -50,8 +50,9 @@ The gain amplitude $a$ of each antenna is set to $1/a$.
 """
 function invert(cal::AmplitudeCalibration)
     output = AmplitudeCalibration(Nant(cal),Nfreq(cal))
-    for i in eachindex(cal.amplitudes)
+    for i in eachindex(output.amplitudes,output.flags,cal.amplitudes,cal.flags)
         output.amplitudes[i] = inv(cal.amplitudes[i])
+        output.flags[i] = cal.flags[i]
     end
     output
 end

--- a/src/gaincal.jl
+++ b/src/gaincal.jl
@@ -50,8 +50,9 @@ The complex gain $g$ of each antenna is set to $1/g$.
 """
 function invert(cal::GainCalibration)
     output = GainCalibration(Nant(cal),Nfreq(cal))
-    for i in eachindex(cal.gains)
+    for i in eachindex(output.gains,output.flags,cal.gains,cal.flags)
         output.gains[i] = inv(cal.gains[i])
+        output.flags[i] = cal.flags[i]
     end
     output
 end

--- a/src/polcal.jl
+++ b/src/polcal.jl
@@ -50,8 +50,9 @@ The Jones matrix $J$ of each antenna is set to $J^{-1}$.
 """
 function invert(cal::PolarizationCalibration)
     output = PolarizationCalibration(Nant(cal),Nfreq(cal))
-    for i in eachindex(cal.jones)
+    for i in eachindex(output.jones,output.flags,cal.jones,cal.flags)
         output.jones[i] = inv(cal.jones[i])
+        output.flags[i] = cal.flags[i]
     end
     output
 end

--- a/src/sourcemodel.jl
+++ b/src/sourcemodel.jl
@@ -199,6 +199,25 @@ function writesources(filename::AbstractString,sources::Vector{PointSource})
     nothing
 end
 
+"""
+    write_ds9_regions(filename,sources::Vector{PointSource})
+
+Write the list of sources to a DS9 region file. This file can then be loaded
+into DS9 to highlight sources within images.
+"""
+function write_ds9_regions(filename,sources::Vector{PointSource})
+    open(filename,"w") do f
+        Base.write(f,"global color=red edit=0 move=0 delete=1\n")
+        Base.write(f,"fk5\n")
+        for source in sources
+            source.name == "Sun" && continue
+            ra  = longitude(source.dir,"deg")
+            dec =  latitude(source.dir,"deg")
+            Base.write(f,"circle($(format_ra(ra)),$(format_dec(dec)),1000\") # text = {$(source.name)}\n")
+        end
+    end
+end
+
 function format_ra(ra::Float64)
     ra /= 15
     ra  = mod(ra,24)

--- a/src/sourcemodel.jl
+++ b/src/sourcemodel.jl
@@ -238,6 +238,7 @@ function format_dec(dec::Float64)
     min = floor(Integer,dec)
     dec = (dec-min)*60
     sec = dec
-    @sprintf("%+dd%02dm%07.4fs",s*deg,min,sec)
+    sign_str = s < 0? "-" : "+"
+    @sprintf("%s%dd%02dm%07.4fs",sign_str,deg,min,sec)
 end
 

--- a/src/subsrc.jl
+++ b/src/subsrc.jl
@@ -44,8 +44,8 @@ function subsrc!(ms::MeasurementSet, dir::Direction)
     flags = get_flags(ms)
 
     j2000 = measure(ms.frame,dir,dir"J2000")
-    l,m = dir2lm(ms.frame,ms.phase_dir,dir)
-    xx,xy,yx,yy = getspec(data,flags,l,m,u,v,w,ν,ant1,ant2)
+    l,m = dir2lm(ms.frame,ms.phase_direction,dir)
+    xx,xy,yx,yy = getspec(data,flags,l,m,ms.u,ms.v,ms.w,ms.ν,ms.ant1,ms.ant2)
 
     model = genvis(xx,xy,yx,yy,l,m,ms.u,ms.v,ms.w,ms.ν)
     subsrc!(data,model)

--- a/test/ampcal.jl
+++ b/test/ampcal.jl
@@ -20,6 +20,7 @@ let
     @test all(cal.flags .== false)
 
     # The inverse of a calibration with unity amplitudes should be itself.
+    rand!(cal.flags)
     inverse = TTCal.invert(cal)
     @test cal.amplitudes == inverse.amplitudes
     @test cal.flags == inverse.flags

--- a/test/gaincal.jl
+++ b/test/gaincal.jl
@@ -26,6 +26,7 @@ let
     @test all(cal.flags .== false)
 
     # The inverse of a calibration with unity gains should be itself.
+    rand!(cal.flags)
     inverse = TTCal.invert(cal)
     @test cal.gains == inverse.gains
     @test cal.flags == inverse.flags

--- a/test/polcal.jl
+++ b/test/polcal.jl
@@ -20,6 +20,7 @@ let
     @test all(cal.flags .== false)
 
     # The inverse of a calibration with identity Jones matrices should be itself.
+    rand!(cal.flags)
     inverse = TTCal.invert(cal)
     @test vecnorm(cal.jones-inverse.jones,Inf) < sqrt(eps(Float32))
     @test cal.flags == inverse.flags

--- a/test/polcal.jl
+++ b/test/polcal.jl
@@ -6,7 +6,7 @@ let
     # Test that the step is zero when the
     # Jones matrices are already at the optimal value.
     jones = ones(JonesMatrix,N)
-    @test norm(TTCal.polcal_step(jones,data,model),Inf) < 5eps(Float32)
+    @test norm(TTCal.polcal_step(jones,data,model),Inf) < sqrt(eps(Float32))
 end
 
 let
@@ -21,7 +21,7 @@ let
 
     # The inverse of a calibration with identity Jones matrices should be itself.
     inverse = TTCal.invert(cal)
-    @test vecnorm(cal.jones-inverse.jones,Inf) < 5eps(Float32)
+    @test vecnorm(cal.jones-inverse.jones,Inf) < sqrt(eps(Float32))
     @test cal.flags == inverse.flags
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,7 @@ function createms(Nant,Nfreq)
     z = randn(Nant)
     u,v,w = xyz2uvw(x,y,z)
     ν = linspace(40e6,60e6,Nfreq) |> collect
-    t = (2015.-1858.)*365.*24.*60.*60. # a rough, current Julian date (in seconds)
+    t = (2015.-1858.)*365.*24.*60.*60. # a rough current Julian date (in seconds)
     ant1,ant2 = ant1ant2(Nant)
 
     frame = ReferenceFrame()

--- a/test/sourcemodel.jl
+++ b/test/sourcemodel.jl
@@ -95,3 +95,12 @@ let
     @test m ≈ m′
 end
 
+let
+    ra = get(q"0h12m34s","deg")
+    @test TTCal.format_ra(ra) == "0h12m34.0000s"
+    dec = get(q"+0d12m34s","deg")
+    @test TTCal.format_dec(dec) == "+0d12m34.0000s"
+    dec = get(q"-0d12m34s","deg")
+    @test TTCal.format_dec(dec) == "-0d12m34.0000s"
+end
+

--- a/test/subsrc.jl
+++ b/test/subsrc.jl
@@ -12,3 +12,18 @@ let
     @test TTCal.get_corrected_data(ms) ≈ zeros(Complex64,4,Nfreq,Nbase)
 end
 
+let
+    Nant = 10
+    Nfreq = 2
+    Nbase = div(Nant*(Nant-1),2) + Nant
+
+    name,ms = createms(Nant,Nfreq)
+    sources = readsources("sources.json")[1:1]
+    ms.table["DATA"] = genvis(ms,sources,TTCal.ConstantBeam())
+    subsrc!(ms,direction(sources[1]))
+
+    @test isapprox(TTCal.get_corrected_data(ms),zeros(Complex64,4,Nfreq,Nbase),atol=1e-1)
+    # note the rough tolerance here has to do with the accuracy of the inverse Fourier
+    # transform used by getspec
+end
+


### PR DESCRIPTION
- implement `write_ds9_regions` for writing source lists to ds9 region files so that it is easier to find sources in the images
- `format_dec` was incorrectly dropping the sign when the degrees of declination was zero
- `subsrc(ms,dir)` is now working with a test
- `applycal` was not correctly applying the calibration flags because they were being dropped by `inverse(cal)`
