### PR TITLE
add an option to save peeling solutions as numpy arrays

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,7 @@
 julia 0.4
 ArgParse
 CasaCore
+FileIO
 JSON
 JLD
 ProgressMeter

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,4 +4,5 @@ CasaCore
 FileIO
 JSON
 JLD
+NPZ
 ProgressMeter

--- a/src/TTCal.jl
+++ b/src/TTCal.jl
@@ -39,6 +39,7 @@ import Base: zero, one, rand, conj, det, inv, norm, kron
 using ArgParse
 using JSON
 using FileIO, JLD
+using NPZ
 using ProgressMeter
 using CasaCore.Measures
 using CasaCore.Tables

--- a/src/TTCal.jl
+++ b/src/TTCal.jl
@@ -38,7 +38,7 @@ import Base: zero, one, rand, conj, det, inv, norm, kron
 
 using ArgParse
 using JSON
-using JLD
+using FileIO, JLD
 using ProgressMeter
 using CasaCore.Measures
 using CasaCore.Tables

--- a/src/calibration.jl
+++ b/src/calibration.jl
@@ -167,6 +167,17 @@ end
 write(filename,calibration::Calibration) = JLD.save(File(format"JLD",filename),"cal",calibration)
 read(filename) = JLD.load(filename,"cal")
 
+function write_for_python(filename,calibration::GainCalibration)
+    gains = zeros(Complex128,2,Nant(calibration),Nfreq(calibration))
+    flags = zeros(      Bool,  Nant(calibration),Nfreq(calibration))
+    for β = 1:Nfreq(calibration), ant = 1:Nant(calibration)
+        gains[1,ant,β] = calibration.jones[ant,β].xx
+        gains[2,ant,β] = calibration.jones[ant,β].yy
+        flags[  ant,β] = calibration.flags[ant,β]
+    end
+    npzwrite(filename,Dict("gains" => gains, "flags" => flags))
+end
+
 """
     fixphase!(cal::Calibration, reference_antenna)
 

--- a/src/calibration.jl
+++ b/src/calibration.jl
@@ -164,7 +164,7 @@ function corrupt!(data::Array{Complex64,3},
     corrupt!(data,flags,cal,ant1,ant2)
 end
 
-write(filename,calibration::Calibration) = JLD.save(filename,"cal",calibration)
+write(filename,calibration::Calibration) = JLD.save(File(format"JLD",filename),"cal",calibration)
 read(filename) = JLD.load(filename,"cal")
 
 """

--- a/src/commandline.jl
+++ b/src/commandline.jl
@@ -99,6 +99,10 @@ end
         help = "A JSON file describing the sources to be peeled from the given measurement set."
         arg_type = ASCIIString
         required = true
+    "--output"
+        help = "If provided, write the direction dependent calibration solutions to disk as NumPy arrays."
+        arg_type = ASCIIString
+        default = ""
     "--beam"
         help = "The name of the beam model to use ($(join(keys(beam_dictionary),",")))."
         arg_type = ASCIIString
@@ -183,11 +187,17 @@ function run_peel(args)
     ms = MeasurementSet(ascii(args["input"]))
     sources = readsources(args["sources"])
     beam = beam_dictionary[args["beam"]]()
-    peel!(GainCalibration,ms,sources,beam,
-                          peeliter=args["peeliter"],
-                          maxiter=args["maxiter"],
-                          tolerance=args["tolerance"],
-                          minuvw=args["minuvw"])
+    calibrations = peel!(GainCalibration,ms,sources,beam,
+                         peeliter=args["peeliter"],
+                         maxiter=args["maxiter"],
+                         tolerance=args["tolerance"],
+                         minuvw=args["minuvw"])
+    if !isempty(args["output"])
+        for i = 1:length(calibrations)
+            filename = args["output"]*"-$i.npz"
+            write_for_python(filename, calibrations[i])
+        end
+    end
 end
 
 function run_applycal(args)

--- a/test/calibration.jl
+++ b/test/calibration.jl
@@ -196,7 +196,7 @@ let
     ms.table["DATA"] = genvis(ms,sources,ConstantBeam())
 
     mycal = gaincal(ms,sources,ConstantBeam(),
-                    maxiter=100,tolerance=Float64(eps(Float64)))
+                    maxiter=100,tolerance=eps(Float64))
     @test !any(mycal.flags)
     @test vecnorm(mycal.jones - ones(DiagonalJonesMatrix,Nant,Nfreq)) < sqrt(eps(Float64))
     unlock(ms)

--- a/test/peel.jl
+++ b/test/peel.jl
@@ -1,0 +1,14 @@
+let
+    Nant = 10
+    Nfreq = 2
+
+    name,ms = createms(Nant,Nfreq)
+    sources = readsources("sources.json")
+    ms.table["DATA"] = genvis(ms,sources,ConstantBeam())
+
+    solutions = peel!(GainCalibration,ms,sources,ConstantBeam(),maxiter=100,tolerance=eps(Float64))
+    for solution in solutions
+        @test vecnorm(solution.jones - ones(DiagonalJonesMatrix,Nant,Nfreq)) < 1e-6
+    end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,5 +16,6 @@ include("genvis.jl")
 include("subsrc.jl")
 include("fitvis.jl")
 include("calibration.jl")
+include("peel.jl")
 include("utm.jl")
 


### PR DESCRIPTION
There will be one file per source peeled.

To read into python:

```
$ ipython
In [1]: from pylab import *
In [2]: sol = np.load("peelings-1.npz")
In [3]: sol["gains"]
In [4]: sol["flags"]
```
