### PR TITLE
detect bad antennas while calibrating

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 TTCal is a calibration routine developed for the OVRO LWA.
 
-**Documentation:** http://mweastwood.github.io/TTCal.jl/
+**Documentation:** http://mweastwood.github.io/TTCal.jl
+
+**Author:** Michael Eastwood
 
 **License:** GPLv3+
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,2 +1,6 @@
-## Contributing
+## Making a Github Account
+
+## Forking the Repository
+
+## Creating a Pull Request
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1,5 +1,3 @@
-## Building this Website
-
 This website is built using [MkDocs](http://www.mkdocs.org/) and hosted
 on [Github Pages](https://pages.github.com/). Building and deploying the
 documentation will require a little bit of setup.
@@ -12,6 +10,6 @@ documentation will require a little bit of setup.
 4. Run `mkdocs serve` and navigate your web browser to
    [http://127.0.0.1:8000](http://127.0.0.1:8000)
    to check that everything looks correct.
-5. Run `mkdocs gh-deploy` to deploy the new documentation to Github Pages.
-6. Commit all your changes.
+5. Commit all your changes.
+6. Run `mkdocs gh-deploy` to deploy the new documentation to Github Pages.
 

--- a/src/calibration.jl
+++ b/src/calibration.jl
@@ -15,6 +15,19 @@
 
 abstract Calibration
 
+macro generate_calibration(name, jones)
+    quote
+        Base.@__doc__ immutable $name <: Calibration
+            jones::Matrix{$jones}
+            flags::Matrix{Bool}
+        end
+        function $name(Nant, Nfreq)
+            $name(ones($jones,Nant,Nfreq), zeros(Bool,Nant,Nfreq))
+        end
+        Base.similar(cal::$name) = $name(Nant(cal), Nfreq(cal))
+    end |> esc
+end
+
 """
     immutable GainCalibration <: Calibration
 
@@ -22,24 +35,14 @@ This type stores the information for calibrating the
 electronic gains of the interferometer. That is, it stores
 complex gains and flags for each antenna, frequency channel,
 and polarization.
-"""
-immutable GainCalibration <: Calibration
-    jones::Matrix{DiagonalJonesMatrix}
-    flags::Matrix{Bool}
-end
 
-"""
     GainCalibration(Nant, Nfreq)
 
 Create a calibration table for `Nant` antennas with
 `Nfreq` frequency channels where all the gains are
 initially set to unity.
 """
-function GainCalibration(Nant,Nfreq)
-    GainCalibration(ones(DiagonalJonesMatrix,Nant,Nfreq),zeros(Bool,Nant,Nfreq))
-end
-
-Base.similar(cal::GainCalibration) = GainCalibration(Nant(cal),Nfreq(cal))
+@generate_calibration GainCalibration DiagonalJonesMatrix
 
 """
     immutable PolarizationCalibration <: Calibration
@@ -48,27 +51,33 @@ This type stores the information for calibrating the
 polarization of the interferometer. That is, it stores
 Jones matrices and flags for each antenna and each
 frequency channel.
-"""
-immutable PolarizationCalibration <: Calibration
-    jones::Matrix{JonesMatrix}
-    flags::Matrix{Bool}
-end
 
-"""
     PolarizationCalibration(Nant, Nfreq)
 
 Create a calibration table for `Nant` antennas with
 `Nfreq` frequency channels where all the Jones matrices
 are initially set to the identity matrix.
 """
-function PolarizationCalibration(Nant,Nfreq)
-    PolarizationCalibration(ones(JonesMatrix,Nant,Nfreq),zeros(Bool,Nant,Nfreq))
-end
-
-Base.similar(cal::PolarizationCalibration) = PolarizationCalibration(Nant(cal),Nfreq(cal))
+@generate_calibration PolarizationCalibration JonesMatrix
 
 Nant( cal::Calibration) = size(cal.jones,1)
 Nfreq(cal::Calibration) = size(cal.jones,2)
+
+write(filename,calibration::Calibration) = JLD.save(File(format"JLD",filename),"cal",calibration)
+read(filename) = JLD.load(filename,"cal")
+
+function write_for_python(filename, calibration::GainCalibration)
+    gains = zeros(Complex128,2, Nant(calibration), Nfreq(calibration))
+    flags = zeros(      Bool,   Nant(calibration), Nfreq(calibration))
+    for β = 1:Nfreq(calibration), ant = 1:Nant(calibration)
+        gains[1,ant,β] = calibration.jones[ant,β].xx
+        gains[2,ant,β] = calibration.jones[ant,β].yy
+        flags[  ant,β] = calibration.flags[ant,β]
+    end
+    npzwrite(filename, Dict("gains" => gains, "flags" => flags))
+end
+
+# corrupt / applycal
 
 """
     corrupt!(data::Array{Complex64,3}, flags::Array{Bool,3},
@@ -83,8 +92,8 @@ function corrupt!(data::Array{Complex64,3}, flags::Array{Bool,3},
         if cal.flags[ant1[α],β] || cal.flags[ant2[α],β]
             flags[:,β,α] = true
         end
-        V = JonesMatrix(data[1,β,α],data[2,β,α],
-                        data[3,β,α],data[4,β,α])
+        V = JonesMatrix(data[1,β,α], data[2,β,α],
+                        data[3,β,α], data[4,β,α])
         J1 = cal.jones[ant1[α],β]
         J2 = cal.jones[ant2[α],β]
         V = J1*V*J2'
@@ -95,6 +104,18 @@ function corrupt!(data::Array{Complex64,3}, flags::Array{Bool,3},
     end
 end
 
+"""
+    corrupt!(data::Array{Complex64,3}, cal::Calibration, ant1, ant2)
+
+Corrupt the model data as if it had been observed
+with an instrument with the given calibration.
+"""
+function corrupt!(data::Array{Complex64,3},
+                  cal::Calibration, ant1, ant2)
+    flags = fill(false, size(data))
+    corrupt!(data, flags, cal, ant1, ant2)
+end
+
 doc"""
     invert(cal::Calibration)
 
@@ -103,8 +124,8 @@ The Jones matrix $J$ of each antenna is set to $J^{-1}$.
 """
 function invert(cal::Calibration)
     output = similar(cal)
-    for i in eachindex(output.jones,output.flags,
-                          cal.jones,   cal.flags)
+    for i in eachindex(output.jones, output.flags,
+                          cal.jones,    cal.flags)
         output.jones[i] = inv(cal.jones[i])
         output.flags[i] = cal.flags[i]
     end
@@ -130,52 +151,226 @@ Apply the calibration to the given measurement set.
     will be written to the CORRECTED_DATA column regardless of whether
     or not the column already exists
 """
-function applycal!(ms::MeasurementSet,
-                   calibration::Calibration;
+function applycal!(ms::MeasurementSet, calibration::Calibration;
                    apply_to_corrected::Bool = false,
                    force_imaging_columns::Bool = false)
     data  = apply_to_corrected? get_corrected_data(ms) : get_data(ms)
     flags = get_flags(ms)
-    applycal!(data,flags,calibration,ms.ant1,ms.ant2)
-    set_corrected_data!(ms,data,force_imaging_columns)
-    set_flags!(ms,flags)
+    applycal!(data, flags, calibration, ms.ant1, ms.ant2)
+    set_corrected_data!(ms, data, force_imaging_columns)
+    set_flags!(ms, flags)
     data
 end
 
-function applycal!(data::Array{Complex64,3},
-                   flags::Array{Bool,3},
-                   cal::Calibration,
-                   ant1,ant2)
+function applycal!(data::Array{Complex64,3}, flags::Array{Bool,3},
+                   cal::Calibration, ant1, ant2)
     inverse_cal = invert(cal)
-    corrupt!(data,flags,inverse_cal,ant1,ant2)
+    corrupt!(data, flags, inverse_cal, ant1, ant2)
     data
 end
 
-"""
-    corrupt!(data::Array{Complex64,3}, cal::Calibration, ant1, ant2)
+# gaincal / polcal
 
-Corrupt the model data as if it had been observed
-with an instrument with the given calibration.
 """
-function corrupt!(data::Array{Complex64,3},
-                  cal::Calibration,
-                  ant1,ant2)
-    flags = fill(false,size(data))
-    corrupt!(data,flags,cal,ant1,ant2)
+    gaincal(ms::MeasurementSet, sources::Vector{Source}, beam::BeamModel;
+            maxiter = 20, tolerance = 1e-3, flag = false, minuvw = 0.0,
+            reference_antenna = "1x", force_imaging_columns = false)
+
+Solve for the interferometer's electronic gains.
+
+**Arguments:**
+
+* `ms` - the measurement set from which to derive the calibration
+* `sources` - the list of points sources to use as the sky model
+* `beam` - the beam model
+
+**Keyword Arguments:**
+
+* `maxiter` - the maximum number of Runge-Kutta steps to take on each
+    frequency channel
+* `tolerance` - the relative tolerance to use while checking to see if
+    more iterations are required
+* `flag` - if set to true, attempt to identify and flag slowly converging
+    calibration solutions
+* `minuvw` - the minimum baseline length (measured in wavelengths) to be
+    used during the calibration procedure
+* `reference_antenna` - a string containing the antenna number and polarization
+    whose phase will be chosen to be zero (eg. "14y" or "62x")
+* `force_imaging_columns` - if this is set to true, the MODEL_DATA column
+    will be created and populated with model visibilities even if it
+    doesn't already exist
+"""
+function gaincal(ms::MeasurementSet, sources::Vector{Source}, beam::BeamModel;
+                 maxiter::Int = 20, tolerance::Float64 = 1e-3, flag::Bool = false,
+                 minuvw::Float64 = 0.0, reference_antenna::ASCIIString = "1x",
+                 force_imaging_columns::Bool = false)
+    sources = abovehorizon(ms.frame, sources)
+    calibration = GainCalibration(ms.Nant, ms.Nfreq)
+    data  = get_data(ms)
+    model = genvis(ms, sources, beam)
+    flags = get_flags(ms)
+    flag_short_baselines!(flags, minuvw, ms.u, ms.v, ms.w, ms.ν)
+    set_model_data!(ms, model, force_imaging_columns)
+    solve!(calibration, data,model, flags,
+           ms.ant1, ms.ant2, maxiter, tolerance, flag)
+    fixphase!(calibration, reference_antenna)
+    calibration
 end
 
-write(filename,calibration::Calibration) = JLD.save(File(format"JLD",filename),"cal",calibration)
-read(filename) = JLD.load(filename,"cal")
+"""
+    polcal(ms::MeasurementSet, sources::Vector{Source}, beam::BeamModel;
+           maxiter = 20, tolerance = 1e-3, minuvw = 0.0,
+           force_imaging_columns = false)
 
-function write_for_python(filename,calibration::GainCalibration)
-    gains = zeros(Complex128,2,Nant(calibration),Nfreq(calibration))
-    flags = zeros(      Bool,  Nant(calibration),Nfreq(calibration))
-    for β = 1:Nfreq(calibration), ant = 1:Nant(calibration)
-        gains[1,ant,β] = calibration.jones[ant,β].xx
-        gains[2,ant,β] = calibration.jones[ant,β].yy
-        flags[  ant,β] = calibration.flags[ant,β]
+Solve for the polarization properties of the interferometer.
+
+**Arguments:**
+
+* `ms` - the measurement set from which to derive the calibration
+* `sources` - the list of points sources to use as the sky model
+* `beam` - the beam model
+
+**Keyword Arguments:**
+
+* `maxiter` - the maximum number of Runge-Kutta steps to take on each
+    frequency channel
+* `tolerance` - the relative tolerance to use while checking to see if
+    more iterations are required
+* `flag` - if set to true, attempt to identify and flag slowly converging
+    calibration solutions
+* `minuvw` - the minimum baseline length (measured in wavelengths) to be
+    used during the calibration procedure
+* `force_imaging_columns` - if this is set to true, the MODEL_DATA column
+    will be created and populated with model visibilities even if it
+    doesn't already exist
+"""
+function polcal(ms::MeasurementSet, sources::Vector{Source}, beam::BeamModel;
+                maxiter::Int = 20, tolerance::Float64 = 1e-3, flag::Bool = false,
+                minuvw::Float64 = 0.0,
+                force_imaging_columns::Bool = false)
+    sources = abovehorizon(ms.frame, sources)
+    calibration = PolarizationCalibration(ms.Nant, ms.Nfreq)
+    data  = get_corrected_data(ms)
+    model = genvis(ms, sources, beam)
+    flags = get_flags(ms)
+    flag_short_baselines!(flags, minuvw, ms.u, ms.v, ms.w, ms.ν)
+    set_model_data!(ms, model)
+    polcal!(calibration, data, model, flags,
+            ms.ant1, ms.ant2, maxiter, tolerance, flag)
+    calibration
+end
+
+function solve!(cal::Calibration, data, model, flags, ant1, ant2,
+                maxiter, tolerance, switch; quiet::Bool = false)
+    quiet || (p = Progress(Nfreq(cal)))
+    for β = 1:Nfreq(cal)
+        solve_onechannel!(slice(cal.jones,:,β),
+                          slice(cal.flags,:,β),
+                          slice(data, :,β,:),
+                          slice(model,:,β,:),
+                          slice(flags,:,β,:),
+                          ant1, ant2, maxiter, tolerance, switch)
+        quiet || next!(p)
     end
-    npzwrite(filename,Dict("gains" => gains, "flags" => flags))
+    if !quiet
+        # Print a summary of the flags
+        print("Flagging summary: ")
+        percentage = [sum(cal.flags[ant,:]) / Nfreq(cal) for ant = 1:Nant(cal)]
+        idx = percentage .> 0.25
+        antennas   = (1:Nant(cal))[idx]
+        percentage = percentage[idx]
+        for i = 1:length(antennas)
+            color = :white
+            percentage[i]  ≥ 0.5 && (color = :red)
+            percentage[i] == 1.0 && (color = :blue)
+            print_with_color(color, string(antennas[i]))
+            i == length(antennas) || print(", ")
+        end
+        print("\n")
+        print("          Legend: ")
+        print_with_color(:white, ">25% flagged"); print(", ")
+        print_with_color(  :red, ">50% flagged"); print(", ")
+        print_with_color( :blue, "100% flagged"); print("\n")
+    end
+end
+
+function solve_onechannel!(jones, jones_flags, data, model, data_flags,
+                           ant1, ant2, maxiter, tolerance, switch)
+    # If the entire channel is flagged, don't bother calibrating.
+    all(data_flags) && (jones_flags[:] = true; return)
+
+    N = length(jones)
+    T = eltype(jones)
+    square_data  = makesquare( data, data_flags, ant1, ant2)
+    square_model = makesquare(model, data_flags, ant1, ant2)
+    best_jones   = copy(jones)
+
+    converged = iterate(stefcal, RK4, maxiter, tolerance, switch,
+                        best_jones, square_data, square_model)
+
+    jones[:] = best_jones
+    jones_flags[:] = solution_flags(best_jones, square_data, square_model, converged)
+    jones,jones_flags
+end
+
+doc"""
+    makesquare(data, flags, ant1, ant2)
+
+Pack the data into a square Hermitian matrix such that
+the data is ordered as follows:
+
+\\[
+    \begin{pmatrix}
+        V_{11} & V_{12} & V_{13} &        & \\\\
+        V_{21} & V_{22} & V_{23} &        & \\\\
+        V_{31} & V_{32} & V_{33} &        & \\\\
+               &        &        & \ddots & \\\\
+    \end{pmatrix}
+\\]
+
+Flagged correlations and autocorrelations are set to zero.
+"""
+function makesquare(data, flags, ant1, ant2)
+    Nbase = length(ant1)
+    Nant = maximum(ant1)
+    output = zeros(JonesMatrix, Nant, Nant)
+    for α = 1:Nbase
+        (flags[1,α] || flags[2,α] || flags[3,α] || flags[4,α]) && continue
+        ant1[α] == ant2[α] && continue
+
+        V = JonesMatrix(data[1,α], data[2,α],
+                        data[3,α], data[4,α])
+        output[ant1[α],ant2[α]] = V
+        output[ant2[α],ant1[α]] = output[ant1[α],ant2[α]]'
+    end
+    output
+end
+
+function solution_flags(jones, data, model, converged)
+    Nant  = length(jones)
+    flags = fill(false, Nant)
+
+    # Flag everything if the solution did not converge.
+    if !converged
+        flags[:] = true
+        return flags
+    end
+
+    # Find flagged antennas by looking for columns of zeros.
+    for j = 1:Nant
+        isflagged = true
+        for i = 1:Nant
+            if data[i,j] != zero(JonesMatrix)
+                isflagged = false
+                break
+            end
+        end
+        if isflagged
+            flags[j] = true
+        end
+    end
+
+    flags
 end
 
 """
@@ -205,181 +400,10 @@ function fixphase!(cal::Calibration, reference_antenna)
     cal
 end
 
-"""
-    gaincal(ms::MeasurementSet, sources::Vector{Source}, beam::BeamModel;
-            maxiter = 20, tolerance = 1e-3, minuvw = 0.0,
-            reference_antenna = "1x", force_imaging_columns = false)
-
-Solve for the interferometer's electronic gains.
-
-**Arguments:**
-
-* `ms` - the measurement set from which to derive the calibration
-* `sources` - the list of points sources to use as the sky model
-* `beam` - the beam model
-
-**Keyword Arguments:**
-
-* `maxiter` - the maximum number of Runge-Kutta steps to take on each
-    frequency channel
-* `tolerance` - the relative tolerance to use while checking to see if
-    more iterations are required
-* `minuvw` - the minimum baseline length (measured in wavelengths) to be
-    used during the calibration procedure
-* `reference_antenna` - a string containing the antenna number and polarization
-    whose phase will be chosen to be zero (eg. "14y" or "62x")
-* `force_imaging_columns` - if this is set to true, the MODEL_DATA column
-    will be created and populated with model visibilities even if it
-    doesn't already exist
-"""
-function gaincal(ms::MeasurementSet,
-                 sources::Vector{Source},
-                 beam::BeamModel;
-                 maxiter::Int = 20,
-                 tolerance::Float64 = 1e-3,
-                 minuvw::Float64 = 0.0,
-                 reference_antenna::ASCIIString = "1x",
-                 force_imaging_columns::Bool = false)
-    sources = abovehorizon(ms.frame,sources)
-    calibration = GainCalibration(ms.Nant,ms.Nfreq)
-    data  = get_data(ms)
-    model = genvis(ms,sources,beam)
-    flags = get_flags(ms)
-    flag_short_baselines!(flags,minuvw,ms.u,ms.v,ms.w,ms.ν)
-    set_model_data!(ms,model,force_imaging_columns)
-    solve!(calibration,data,model,flags,
-           ms.ant1,ms.ant2,maxiter,tolerance)
-    fixphase!(calibration,reference_antenna)
-    calibration
-end
-
-"""
-    polcal(ms::MeasurementSet, sources::Vector{Source}, beam::BeamModel;
-           maxiter = 20, tolerance = 1e-3, minuvw = 0.0,
-           force_imaging_columns = false)
-
-Solve for the polarization properties of the interferometer.
-
-**Arguments:**
-
-* `ms` - the measurement set from which to derive the calibration
-* `sources` - the list of points sources to use as the sky model
-* `beam` - the beam model
-
-**Keyword Arguments:**
-
-* `maxiter` - the maximum number of Runge-Kutta steps to take on each
-    frequency channel
-* `tolerance` - the relative tolerance to use while checking to see if
-    more iterations are required
-* `minuvw` - the minimum baseline length (measured in wavelengths) to be
-    used during the calibration procedure
-* `force_imaging_columns` - if this is set to true, the MODEL_DATA column
-    will be created and populated with model visibilities even if it
-    doesn't already exist
-"""
-function polcal(ms::MeasurementSet,
-                sources::Vector{Source},
-                beam::BeamModel;
-                maxiter::Int = 20,
-                tolerance::Float64 = 1e-3,
-                minuvw::Float64 = 0.0,
-                force_imaging_columns::Bool = false)
-    sources = abovehorizon(ms.frame,sources)
-    calibration = PolarizationCalibration(ms.Nant,ms.Nfreq)
-    data  = get_corrected_data(ms)
-    model = genvis(ms,sources,beam)
-    flags = get_flags(ms)
-    flag_short_baselines!(flags,minuvw,ms.u,ms.v,ms.w,ms.ν)
-    set_model_data!(ms,model)
-    polcal!(calibration,data,model,flags,
-            ms.ant1,ms.ant2,maxiter,tolerance)
-    calibration
-end
-
-function solve!(calibration::Calibration,
-                data, model, flags, ant1, ant2,
-                maxiter, tolerance; quiet = false)
-    quiet || (p = Progress(Nfreq(calibration), 1, "Thinking...", 50))
-    for β = 1:Nfreq(calibration)
-        solve_onechannel!(slice(calibration.jones,:,β),
-                          slice(calibration.flags,:,β),
-                          slice(data, :,β,:),
-                          slice(model,:,β,:),
-                          slice(flags,:,β,:),
-                          ant1, ant2, maxiter, tolerance)
-        quiet || next!(p)
-    end
-    if !quiet && sum(calibration.flags) > 0.5length(calibration.flags)
-        warn("Over half of the calibration solutions are flagged.")
-    end
-end
-
-function solve_onechannel!(jones, jones_flags,
-                           data, model, data_flags,
-                           ant1, ant2, maxiter, tolerance)
-    # If the entire channel is flagged, don't bother calibrating.
-    all(data_flags) && (jones_flags[:] = true; return)
-
-    N = length(jones)
-    T = eltype(jones)
-    square_data  = makesquare( data,data_flags,ant1,ant2)
-    square_model = makesquare(model,data_flags,ant1,ant2)
-    best_jones   = copy(jones)
-
-    converged = iterate(stefcal,RK4,maxiter,tolerance,
-                        best_jones,square_data,square_model)
-
-    # Propagate antenna flags to the calibration solutions.
-    # A flagged antenna should correspond to a row and column
-    # of zeros in both square_data and square_model.
-    antenna_flags = all(square_data .== zero(JonesMatrix),2)
-
-    # Flag the entire channel if the solution did not converge.
-    # However, we'll still write out our best guess for what
-    # the gains should be.
-    converged || (antenna_flags[:] = true)
-
-    jones[:] = best_jones
-    jones_flags[:] = antenna_flags
-    jones,jones_flags
-end
+# step functions
 
 doc"""
-    makesquare(data, flags, ant1, ant2)
-
-Pack the data into a square Hermitian matrix such that
-the data is ordered as follows:
-
-\\[
-    \begin{pmatrix}
-        V_{11} & V_{12} & V_{13} &        & \\\\
-        V_{21} & V_{22} & V_{23} &        & \\\\
-        V_{31} & V_{32} & V_{33} &        & \\\\
-               &        &        & \ddots & \\\\
-    \end{pmatrix}
-\\]
-
-Flagged correlations and autocorrelations are set to zero.
-"""
-function makesquare(data, flags, ant1, ant2)
-    Nbase = length(ant1)
-    Nant = maximum(ant1)
-    output = zeros(JonesMatrix,Nant,Nant)
-    for α = 1:Nbase
-        (flags[1,α] || flags[2,α] || flags[3,α] || flags[4,α]) && continue
-        ant1[α] == ant2[α] && continue
-
-        V = JonesMatrix(data[1,α],data[2,α],
-                        data[3,α],data[4,α])
-        output[ant1[α],ant2[α]] = V
-        output[ant2[α],ant1[α]] = output[ant1[α],ant2[α]]'
-    end
-    output
-end
-
-doc"""
-    stefcal_step(input,data,model) -> step
+    stefcal_step(input, data, model) -> step
 
 Given the `data` and `model` visibilities, and the current
 guess for the Jones matrices, solve for `step` such
@@ -389,7 +413,7 @@ The update step is defined such that the new value of the
 Jones matrices minimizes
 
 \\[
-    \sum_{i,j}\|V_{i,j} - G_i M_{i,j} G_{j,new}^*\|^2$,
+    \sum_{i,j}\|V_{i,j} - G_i M_{i,j} G_{j,\rm new}^*\|^2,
 \\]
 
 where $i$ and $j$ label the antennas, $V$ labels the measured
@@ -401,7 +425,7 @@ labels the Jones matrices.
 * Michell, D. et al. 2008, JSTSP, 2, 5.
 * Salvini, S. & Wijnholds, S. 2014, A&A, 571, 97.
 """
-function stefcal_step{T}(input::AbstractVector{T},data,model)
+function stefcal_step{T}(input::AbstractVector{T}, data, model)
     Nant = length(input)
     step = similar(input)
     @inbounds for j = 1:Nant
@@ -410,23 +434,71 @@ function stefcal_step{T}(input::AbstractVector{T},data,model)
         for i = 1:Nant
             GM = input[i]*model[i,j]
             V  = data[i,j]
-            numerator   += inner_multiply(T,GM,V)
-            denominator += inner_multiply(T,GM,GM)
+            numerator   += inner_multiply(T, GM, V)
+            denominator += inner_multiply(T, GM, GM)
         end
         ok = abs(det(denominator)) > eps(Float64)
-        step[j] = ifelse(ok,(denominator\numerator)' - input[j],zero(T))
+        step[j] = ifelse(ok, (denominator\numerator)' - input[j], zero(T))
     end
     step
 end
 
-immutable StefCalStep <: StepFunction end
-call(::StefCalStep,input,data,model) = stefcal_step(input,data,model)
-const stefcal = StefCalStep()
-
-@inline function inner_multiply(::Type{DiagonalJonesMatrix},X,Y)
+@inline function inner_multiply(::Type{DiagonalJonesMatrix}, X, Y)
     DiagonalJonesMatrix(X.xx'*Y.xx + X.yx'*Y.yx,
                         X.xy'*Y.xy + X.yy'*Y.yy)
 end
 
-@inline inner_multiply(::Type{JonesMatrix},X,Y) = X'*Y
+@inline inner_multiply(::Type{JonesMatrix}, X, Y) = X'*Y
+
+immutable StefCalStep <: StepFunction end
+const stefcal = StefCalStep()
+call(::StefCalStep, input, data, model) = step = stefcal_step(input, data, model)
+
+function check!(::StefCalStep, input, data, model)
+    Nant = length(input)
+
+    # There are two types of residuals that we can compute:
+    #
+    # 1. |Vᵢⱼ - GᵢMᵢⱼGⱼ|, and
+    # 2. |Gᵢ⁻¹VᵢⱼGⱼ⁻¹ - Mᵢⱼ|.
+    #
+    # The calibration algorithm used by TTCal attempts to minimize
+    # the first kind of residual. In my experience TTCal is very good
+    # at finding a solution where the first residual is low even when
+    # there exists a number of antennas that are feeding garbage into
+    # the algorithm and should be flagged.
+    #
+    # For example an antenna that is unplugged and is simply picking
+    # up noise can be made to minimize the first residual by dialing
+    # down the gain amplitudes. However this will make the second
+    # residual large.
+    #
+    # Therefore, let's look for antennas where the second kind of
+    # residual is exploding.
+
+    residual = zeros(Nant, Nant)
+    for j = 1:Nant, i = j+1:Nant
+        data[i,j] == zero(JonesMatrix) && continue
+        residual[i,j] = norm(input[i]\data[i,j]/input[j]' - model[i,j])
+        residual[j,i] = residual[i,j]
+    end
+
+    δ = zeros(Nant)
+    for i = 1:Nant
+        δ[i] = median(slice(residual, :, i))
+    end
+
+    μ = mean(δ)
+    σ =  std(δ)
+    for i = 1:Nant
+        if abs(δ[i] - μ) > 10σ
+            data[i,:] = zero(JonesMatrix)
+            data[:,i] = zero(JonesMatrix)
+            model[i,:] = zero(JonesMatrix)
+            model[:,i] = zero(JonesMatrix)
+        end
+    end
+
+    nothing
+end
 

--- a/src/calibration.jl
+++ b/src/calibration.jl
@@ -327,8 +327,8 @@ function solve_onechannel!(jones, jones_flags,
     square_model = makesquare(model,data_flags,ant1,ant2)
     best_jones   = copy(jones)
 
-    converged = @iterate(StefCalStep(),RK4,maxiter,tolerance,
-                         best_jones,square_data,square_model)
+    converged = iterate(stefcal,RK4,maxiter,tolerance,
+                        best_jones,square_data,square_model)
 
     # Propagate antenna flags to the calibration solutions.
     # A flagged antenna should correspond to a row and column
@@ -419,13 +419,14 @@ function stefcal_step{T}(input::AbstractVector{T},data,model)
     step
 end
 
+immutable StefCalStep <: StepFunction end
+call(::StefCalStep,input,data,model) = stefcal_step(input,data,model)
+const stefcal = StefCalStep()
+
 @inline function inner_multiply(::Type{DiagonalJonesMatrix},X,Y)
     DiagonalJonesMatrix(X.xx'*Y.xx + X.yx'*Y.yx,
                         X.xy'*Y.xy + X.yy'*Y.yy)
 end
 
 @inline inner_multiply(::Type{JonesMatrix},X,Y) = X'*Y
-
-immutable StefCalStep <: StepFunction end
-call(::StefCalStep,g,V,M) = stefcal_step(g,V,M)
 

--- a/src/calibration.jl
+++ b/src/calibration.jl
@@ -479,15 +479,12 @@ function check!(::StefCalStep, input, data, model)
         δ[i] = median(slice(residual, :, i))
     end
 
-    μ = mean(δ)
-    σ =  std(δ)
-    for i = 1:Nant
-        if abs(δ[i] - μ) > 10σ
-            data[i,:] = zero(JonesMatrix)
-            data[:,i] = zero(JonesMatrix)
-            model[i,:] = zero(JonesMatrix)
-            model[:,i] = zero(JonesMatrix)
-        end
+    worst_antenna = indmax(δ)
+    if δ[worst_antenna] > 10median(δ)
+        data[worst_antenna,:] = zero(JonesMatrix)
+        data[:,worst_antenna] = zero(JonesMatrix)
+        model[worst_antenna,:] = zero(JonesMatrix)
+        model[:,worst_antenna] = zero(JonesMatrix)
     end
 
     nothing

--- a/src/fitvis.jl
+++ b/src/fitvis.jl
@@ -45,7 +45,7 @@ function fitvis(data,flags,l,m,
                 u,v,w,ν,ant1,ant2,
                 maxiter,tolerance)
     lm = [l;m]
-    converged = iterate(FitVisStep(),RK4,maxiter,tolerance,
+    converged = iterate(FitVisStep(),RK4,maxiter,tolerance,false,
                         lm,data,flags,u,v,w,ν,ant1,ant2)
     lm[1],lm[2]
 end

--- a/src/fitvis.jl
+++ b/src/fitvis.jl
@@ -45,8 +45,8 @@ function fitvis(data,flags,l,m,
                 u,v,w,ν,ant1,ant2,
                 maxiter,tolerance)
     lm = [l;m]
-    converged = @iterate(FitVisStep(),RK4,maxiter,tolerance,
-                         lm,data,flags,u,v,w,ν,ant1,ant2)
+    converged = iterate(FitVisStep(),RK4,maxiter,tolerance,
+                        lm,data,flags,u,v,w,ν,ant1,ant2)
     lm[1],lm[2]
 end
 

--- a/src/peel.jl
+++ b/src/peel.jl
@@ -66,7 +66,7 @@ function peel!(calibrations,coherencies,data,flags,
     end
 
     # Derive a calibration towards each source
-    p = Progress(peeliter*Nsource, 1, "Peeling...", 50)
+    p = Progress(peeliter*Nsource)
     for iter = 1:peeliter
         for s = 1:Nsource
             coherency = coherencies[s]

--- a/src/peel.jl
+++ b/src/peel.jl
@@ -81,7 +81,7 @@ function peel!(calibrations,coherencies,data,flags,
             # of the current source.
             solve!(calibration_toward_source,
                    data,coherency,flags,
-                   ant1,ant2,maxiter,tolerance,
+                   ant1,ant2,maxiter,tolerance,false,
                    quiet = true)
 
             # Take the source back out of the measured visibilities,

--- a/src/rungekutta.jl
+++ b/src/rungekutta.jl
@@ -14,6 +14,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 abstract StepFunction
+abstract RKStepFunction
 
 """
 The Butcher tableau for the 2nd-order Runge-Kutta method.
@@ -36,75 +37,106 @@ const RK4_tableau = [1/2 0.0 0.0 0.0;
                      0.0 0.0 1.0 0.0;
                      1/6 1/3 1/3 1/6]
 
-"""
-This singleton type is used to indicate which Runge-Kutta method
-should be used. For example, `RK{4}` tells us to use the RK4 method.
-"""
-immutable RK{N} end
-RK(N) = RK{N}()
-rkorder{N}(::RK{N}) = N
-rkorder{N}(::Type{RK{N}}) = N
-
-const RK2 = RK(2)
-const RK3 = RK(3)
-const RK4 = RK(4)
-
-@generated function rkstep(step::StepFunction,rk::RK,x,args...)
-    N = rkorder(rk)
-    T = eltype(x)
-    Ndims = ndims(x)
-    tableau = symbol("RK$(N)_tableau")
-
+macro generate_step(name, tableau)
+    funcname = symbol(name, "_func")
+    typename = symbol(name, "_type")
     quote
-        # Calculate the intermediate steps k
-        k = Array{Array{$T,$Ndims}}($N)
-        k[1] = step(x,args...)
-        for row = 1:$N-1
-            x′ = copy(x)
-            for col = 1:row
-                $tableau[row,col] == 0 && continue
+        function $funcname(step::StepFunction, x, args...)
+            N = length(x)
+            order = size($tableau, 1)
+
+            # Calculate the intermediate steps
+            k = Array(typeof(x), order)
+            k[1] = step(x, args...)
+            for row = 1:order-1
+                x′ = copy(x)
+                for col = 1:row
+                    $tableau[row,col] == 0 && continue
+                    k′ = k[col]
+                    for i in eachindex(x′, k′)
+                        @inbounds x′[i] += k′[i] * $tableau[row,col]
+                    end
+                end
+                k[row+1] = step(x′, args...)
+            end
+
+            # Calculate the final step
+            δ = zeros(eltype(x), size(x))
+            for col = 1:order
                 k′ = k[col]
-                for i in eachindex(x′)
-                    @inbounds x′[i] += k′[i]*$tableau[row,col]
+                for i in eachindex(δ, k′)
+                    @inbounds δ[i] += k′[i] * $tableau[order,col]
                 end
             end
-            k[row+1] = step(x′,args...)
+            δ
         end
-        # Calculate the final step δ
-        δ = zeros(eltype(x),size(x))
-        for col = 1:$N
-            k′ = k[col]
-            for i in eachindex(δ)
-                @inbounds δ[i] += k′[i]*$tableau[$N,col]
-            end
-        end
-        δ
-    end
+
+        immutable $typename <: RKStepFunction end
+        call(::$typename, x, args...) = $funcname(x, args...)
+        Base.@__doc__ const $name = $typename()
+    end |> esc
 end
 
-@doc """
-Take a Runge-Kutta step.
-* `step(x,args...)` must return the list of steps to take from the given location `x`
-* `rk` is the order of the Runge-Kutta method to use (eg. `RK4`)
+"""
+    RK2(step, x, args...)
+
+Take a 2nd-order Runge-Kutta step.
+
+**Arguments:**
+
+* `step(x, args...)` must return the step to take from the starting location `x`
 * `x` is the starting location
 * `args` is simply passed on as the second argument to `step`
-""" rkstep
+"""
+@generate_step RK2 RK2_tableau
 
-macro iterate(step,rk,maxiter,tolerance,x,args...)
-    quote
-        iter = 0
-        converged = false
-        while !converged && iter < $maxiter
-            δ = rkstep($step,$rk,$x,$(args...))
-            if vecnorm(δ) < $tolerance*vecnorm($x)
-                converged = true
-            end
-            for i in eachindex($x)
-                $x[i] += δ[i]
-            end
-            iter += 1
+"""
+    RK3(step, x, args...)
+
+Take a 3rd-order Runge-Kutta step.
+
+**Arguments:**
+
+* `step(x, args...)` must return the step to take from the starting location `x`
+* `x` is the starting location
+* `args` is simply passed on as the second argument to `step`
+"""
+@generate_step RK3 RK3_tableau
+
+"""
+    RK4(step, x, args...)
+
+Take a 4th-order Runge-Kutta step.
+
+**Arguments:**
+
+* `step(x, args...)` must return the step to take from the starting location `x`
+* `x` is the starting location
+* `args` is simply passed on as the second argument to `step`
+"""
+@generate_step RK4 RK4_tableau
+
+"""
+    iterate(step, rkstep, maxiter, tolerance, x, args...)
+
+Repeatedly call `rkstep(step, x, args...)` and updating the value of `x`
+until either the step size is sufficiently small or the maximum number
+of iterations is reached.
+"""
+function iterate(step::StepFunction, rkstep::RKStepFunction,
+                 maxiter, tolerance, x, args...)
+    iter = 0
+    converged = false
+    while !converged && iter < maxiter
+        δ = rkstep(step, x, args...)
+        if vecnorm(δ) < tolerance * vecnorm(x)
+            converged = true
         end
-        converged
+        for i in eachindex(x, δ)
+            x[i] += δ[i]
+        end
+        iter += 1
     end
+    converged
 end
 

--- a/src/rungekutta.jl
+++ b/src/rungekutta.jl
@@ -117,14 +117,17 @@ Take a 4th-order Runge-Kutta step.
 @generate_step RK4 RK4_tableau
 
 """
-    iterate(step, rkstep, maxiter, tolerance, x, args...)
+    iterate(step, rkstep, maxiter, tolerance, switch, x, args...)
 
-Repeatedly call `rkstep(step, x, args...)` and updating the value of `x`
+Repeatedly call `rkstep(step, x, args...)` while updating the value of `x`
 until either the step size is sufficiently small or the maximum number
 of iterations is reached.
+
+If `switch` is set to `true`, every iteration will also run `check!(step, x, args...)`.
+This function can then be used to constrain or help the iteration converge.
+For example `check!` can be used to update flags on bad antennas.
 """
-function iterate(step::StepFunction, rkstep::RKStepFunction,
-                 maxiter, tolerance, x, args...)
+function iterate(step::StepFunction, rkstep, maxiter, tolerance, switch, x, args...)
     iter = 0
     converged = false
     while !converged && iter < maxiter
@@ -135,8 +138,11 @@ function iterate(step::StepFunction, rkstep::RKStepFunction,
         for i in eachindex(x, δ)
             x[i] += δ[i]
         end
+        switch && check!(step, x, args...) # hook that allows flags to be updated while iterating
         iter += 1
     end
     converged
 end
+
+check!(::StepFunction, x, args...) = nothing
 

--- a/src/stokes.jl
+++ b/src/stokes.jl
@@ -60,6 +60,8 @@ immutable HermitianJonesMatrix
     yy::Float64
 end
 
+typealias AnyJonesMatrix Union{JonesMatrix,DiagonalJonesMatrix,HermitianJonesMatrix}
+
 zero(::Type{JonesMatrix}) = JonesMatrix(0,0,0,0)
 one(::Type{JonesMatrix}) = JonesMatrix(1,0,0,1) # the identity matrix
 rand(::Type{JonesMatrix}) = JonesMatrix(rand(Complex128),rand(Complex128),rand(Complex128),rand(Complex128))
@@ -113,6 +115,8 @@ end
 @inline *(a::Number,J::DiagonalJonesMatrix) = DiagonalJonesMatrix(a*J.xx,a*J.yy)
 @inline *(J::DiagonalJonesMatrix,a::Number) = *(a,J)
 
+@inline /(J::JonesMatrix,a::Number) = JonesMatrix(J.xx/a,J.xy/a,J.yx/a,J.yy/a)
+@inline /(J::DiagonalJonesMatrix,a::Number) = DiagonalJonesMatrix(J.xx/a,J.yy/a)
 @inline /(J::HermitianJonesMatrix,a::Number) = HermitianJonesMatrix(J.xx/a,J.xy/a,J.yy/a)
 
 @inline function *(J1::JonesMatrix,J2::JonesMatrix)
@@ -134,8 +138,8 @@ end
 
 @inline *(J1::DiagonalJonesMatrix,J2::DiagonalJonesMatrix) = DiagonalJonesMatrix(J1.xx*J2.xx,J1.yy*J2.yy)
 
-@inline \(J1::JonesMatrix,J2::JonesMatrix) = inv(J1)*J2
-@inline \(J1::DiagonalJonesMatrix,J2::DiagonalJonesMatrix) = DiagonalJonesMatrix(J2.xx/J1.xx,J2.yy/J1.yy)
+@inline \(J1::AnyJonesMatrix,J2::AnyJonesMatrix) = inv(J1)*J2
+@inline /(J1::AnyJonesMatrix,J2::AnyJonesMatrix) = J1*inv(J2)
 
 @inline conj(J::JonesMatrix) = JonesMatrix(conj(J.xx),conj(J.xy),conj(J.yx),conj(J.yy))
 @inline conj(J::DiagonalJonesMatrix) = DiagonalJonesMatrix(conj(J.xx),conj(J.yy))

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+BaseTestNext

--- a/test/calibration.jl
+++ b/test/calibration.jl
@@ -1,211 +1,197 @@
-# Test that applycal! and corrupt! are inverses
-let
-    Nant = 10
+@testset "Calibration Tests" begin
+    Nant  = 10
     Nfreq = 2
     Nbase = div(Nant*(Nant-1),2) + Nant
     ant1,ant2 = ant1ant2(Nant)
 
-    data  = rand(Complex64,4,Nfreq,Nbase)
-    data′ = copy(data)
-    flags = zeros(Bool,4,Nfreq,Nbase)
+    @testset "types" begin
+        for T in (GainCalibration,PolarizationCalibration)
+            cal = T(Nant,Nfreq)
+            el  = eltype(cal.jones)
+            @test TTCal.Nant(cal) == Nant
+            @test TTCal.Nfreq(cal) == Nfreq
+            @test cal.jones == ones(el,Nant,Nfreq)
+            @test cal.flags == zeros(Bool,Nant,Nfreq)
 
-    for T in (GainCalibration,PolarizationCalibration)
-        cal = T(Nant,Nfreq)
+            # Test that the inverse of an identity matrix is itself
+            rand!(cal.flags)
+            inverse = TTCal.invert(cal)
+            @test vecnorm(cal.jones - inverse.jones) == 0
+            @test cal.flags == inverse.flags
+        end
+    end
+
+    @testset "applycal" begin
+        data  = rand(Complex64,4,Nfreq,Nbase)
+        data′ = copy(data)
+        flags = zeros(Bool,4,Nfreq,Nbase)
+
+        for T in (GainCalibration,PolarizationCalibration)
+            g = rand(Complex64)
+            random_cal   = T(Nant,Nfreq)
+            constant_cal = T(Nant,Nfreq)
+            for i in eachindex(random_cal.jones, constant_cal.jones)
+                random_cal.jones[i]   =  rand(eltype(  random_cal.jones))
+                constant_cal.jones[i] = g*one(eltype(constant_cal.jones))
+            end
+
+            # Test that applycal! and corrupt! are inverses
+            data = copy(data′)
+            corrupt!(data,flags,random_cal,ant1,ant2)
+            applycal!(data,flags,random_cal,ant1,ant2)
+            @test data ≈ data′
+
+            # Test that we get the correct answer with a simple calibration
+            data = copy(data′)
+            applycal!(data,flags,constant_cal,ant1,ant2)
+            @test data ≈ data′/(g*conj(g))
+
+            # Test the interface for interacting with measurement sets
+            data = copy(data′)
+            name,ms = createms(Nant,Nfreq)
+            ms.table["DATA"] = data
+            applycal!(ms,constant_cal)
+            data = TTCal.get_data(ms)
+            @test data ≈ data′/(g*conj(g))
+
+            # Test the command line interface
+            data = copy(data′)
+            cal_name = tempname()*".jld"
+            TTCal.write(cal_name,constant_cal)
+            name,ms = createms(Nant,Nfreq)
+            ms.table["DATA"] = data
+            TTCal.main(["applycal","--input",name,"--calibration",cal_name])
+            data = TTCal.get_data(ms)
+            @test data ≈ data′/(g*conj(g))
+        end
+    end
+
+    @testset "stefcal" begin
+        N = 100
+        data  = [rand(JonesMatrix) for i = 1:N, j = 1:N]
+        model = copy(data)
+
+        # Test that the step is zero when the Jones matrices are already at the optimal value
+        jones = ones(DiagonalJonesMatrix,N)
+        @test TTCal.stefcal_step(jones,data,model) |> vecnorm < N*eps(Float64)
+        jones = ones(JonesMatrix,N)
+        @test TTCal.stefcal_step(jones,data,model) |> vecnorm < N*eps(Float64)
+    end
+
+    @testset "fixphase" begin
+        cal = GainCalibration(Nant,Nfreq)
         for i in eachindex(cal.jones)
             cal.jones[i] = rand(eltype(cal.jones))
         end
-        corrupt!(data,flags,cal,ant1,ant2)
-        applycal!(data,flags,cal,ant1,ant2)
-        @test data ≈ data′
-    end
-end
 
-# Test the interface for interacting with measurement sets
-let
-    Nant = 10
-    Nfreq = 2
-    Nbase = div(Nant*(Nant-1),2) + Nant
-
-    g = 2
-    cal = GainCalibration(Nant,Nfreq)
-    for i in eachindex(cal.jones)
-        cal.jones[i] = DiagonalJonesMatrix(g,g)
-    end
-
-    # Run as `applycal(...)`
-    name,ms = createms(Nant,Nfreq)
-    ms.table["DATA"] = rand(Complex64,4,Nfreq,Nbase)
-    data  = TTCal.get_data(ms)
-    applycal!(ms,cal)
-    data′ = TTCal.get_data(ms)
-    @test data/(g*conj(g)) ≈ data′
-    unlock(ms)
-
-    # Run from `main(...)`
-    cal_name = tempname()*".jld"
-    TTCal.write(cal_name,cal)
-    TTCal.main(["applycal","--input",name,"--calibration",cal_name])
-    calibrated_ms = Table(name)
-    @test data′/(g*conj(g)) ≈ calibrated_ms["DATA"]
-end
-
-let
-    N = 100
-    data  = [rand(JonesMatrix) for i = 1:N, j = 1:N]
-    model = copy(data)
-
-    # Test that the step is zero when the
-    # Jones matrices are already at the optimal value.
-    jones = ones(DiagonalJonesMatrix,N)
-    @test TTCal.stefcal_step(jones,data,model) |> vecnorm < N*eps(Float64)
-    jones = ones(JonesMatrix,N)
-    @test TTCal.stefcal_step(jones,data,model) |> vecnorm < N*eps(Float64)
-end
-
-let
-    Nant = 10
-    Nfreq = 20
-
-    for T in (GainCalibration,PolarizationCalibration)
-        cal = T(Nant,Nfreq)
-        el  = eltype(cal.jones)
-        @test TTCal.Nant(cal) == Nant
-        @test TTCal.Nfreq(cal) == Nfreq
-        @test cal.jones == ones(el,Nant,Nfreq)
-        @test cal.flags == zeros(Bool,Nant,Nfreq)
-
-        # The inverse of a calibration with identity Jones matrices should be itself.
-        rand!(cal.flags)
-        inverse = TTCal.invert(cal)
-        @test vecnorm(cal.jones - inverse.jones) == 0
-        @test cal.flags == inverse.flags
-    end
-end
-
-let
-    Nant = 10
-    Nfreq = 3
-    cal = GainCalibration(Nant,Nfreq)
-    for i in eachindex(cal.jones)
-        cal.jones[i] = rand(eltype(cal.jones))
-    end
-
-    # Test that fixphase! actually sets the phase to zero.
-
-    TTCal.fixphase!(cal,"1x")
-    for β = 1:Nfreq
-        @test angle(cal.jones[1,β].xx) < eps(Float64)
-    end
-
-    TTCal.fixphase!(cal,"2y")
-    for β = 1:Nfreq
-        @test angle(cal.jones[2,β].yy) < eps(Float64)
-    end
-
-    TTCal.fixphase!(cal,"5y")
-    for β = 1:Nfreq
-        @test angle(cal.jones[5,β].yy) < eps(Float64)
-    end
-end
-
-function test_solve(cal,data,model,
-                    ant1,ant2,maxiter,tolerance)
-    Nant = TTCal.Nant(cal)
-    Nfreq = TTCal.Nfreq(cal)
-
-    # Run as `solve!(...)`
-    mycal = similar(cal)
-    flags = zeros(Bool,size(data))
-    TTCal.solve!(mycal,data,model,flags,
-                 ant1,ant2,maxiter,tolerance,false)
-    TTCal.fixphase!(mycal,"1x")
-    @test !any(mycal.flags)
-    @test vecnorm(mycal.jones-cal.jones) < eps(Float32)
-end
-
-# Unity gains
-let
-    Nant = 10
-    Nfreq = 2
-    Nbase = div(Nant*(Nant-1),2) + Nant
-    ant1,ant2 = ant1ant2(Nant)
-
-    data  = Array{Complex64,3}(complex(randn(4,Nfreq,Nbase),randn(4,Nfreq,Nbase)))
-    model = copy(data)
-
-    for T in (GainCalibration,PolarizationCalibration)
-        cal = T(Nant,Nfreq)
-        test_solve(cal,data,model,ant1,ant2,100,eps(Float64))
-    end
-end
-
-# Random gains
-let
-    Nant = 10
-    Nfreq = 2
-    Nbase = div(Nant*(Nant-1),2) + Nant
-    ant1,ant2 = ant1ant2(Nant)
-
-    for T in (GainCalibration,PolarizationCalibration)
-        cal = T(Nant,Nfreq)
-        for i in eachindex(cal.jones)
-            cal.jones[i] = rand(eltype(cal.jones))
-        end
+        # Test that fixphase! actually sets the phase to zero.
         TTCal.fixphase!(cal,"1x")
+        for β = 1:Nfreq
+            @test angle(cal.jones[1,β].xx) < eps(Float64)
+        end
+        TTCal.fixphase!(cal,"2y")
+        for β = 1:Nfreq
+            @test angle(cal.jones[2,β].yy) < eps(Float64)
+        end
+        TTCal.fixphase!(cal,"5y")
+        for β = 1:Nfreq
+            @test angle(cal.jones[5,β].yy) < eps(Float64)
+        end
+    end
+
+    function test_solve(cal,data,model,maxiter,tolerance)
+        Nant  = TTCal.Nant( cal)
+        Nfreq = TTCal.Nfreq(cal)
+
+        # Run as `solve!(...)`
+        mycal = similar(cal)
+        flags = zeros(Bool,size(data))
+        TTCal.solve!(mycal,data,model,flags,ant1,ant2,maxiter,tolerance,false,quiet=true)
+        TTCal.fixphase!(mycal,"1x")
+        @test !any(mycal.flags)
+        @test vecnorm(mycal.jones-cal.jones) < eps(Float32)
+    end
+
+    @testset "unity gains" begin
         data  = Array{Complex64,3}(complex(randn(4,Nfreq,Nbase),randn(4,Nfreq,Nbase)))
         model = copy(data)
-        corrupt!(data,cal,ant1,ant2)
-        test_solve(cal,data,model,ant1,ant2,200,eps(Float64))
-    end
-end
-
-# Random gains and corrupted autocorrelations
-let
-    Nant = 10
-    Nfreq = 2
-    Nbase = div(Nant*(Nant-1),2) + Nant
-    ant1,ant2 = ant1ant2(Nant)
-
-    for T in (GainCalibration,PolarizationCalibration)
-        cal = T(Nant,Nfreq)
-        for i in eachindex(cal.jones)
-            cal.jones[i] = rand(eltype(cal.jones))
+        for T in (GainCalibration,PolarizationCalibration)
+            cal = T(Nant,Nfreq)
+            test_solve(cal,data,model,100,eps(Float64))
         end
-        TTCal.fixphase!(cal,"1x")
-        data  = Array{Complex64,3}(complex(randn(4,Nfreq,Nbase),randn(4,Nfreq,Nbase)))
-        model = copy(data)
-        corrupt!(data,cal,ant1,ant2)
-        α = 1
-        for ant = 1:Nant
-            data[:,:,α] = rand(4,Nfreq)
-            α += Nant-ant+1
-        end
-        test_solve(cal,data,model,ant1,ant2,200,eps(Float64))
     end
 
-end
+    @testset "random gains" begin
+        for T in (GainCalibration,PolarizationCalibration)
+            cal = T(Nant,Nfreq)
+            for i in eachindex(cal.jones)
+                cal.jones[i] = rand(eltype(cal.jones))
+            end
+            TTCal.fixphase!(cal,"1x")
+            data  = Array{Complex64,3}(complex(randn(4,Nfreq,Nbase),randn(4,Nfreq,Nbase)))
+            model = copy(data)
+            corrupt!(data,cal,ant1,ant2)
+            test_solve(cal,data,model,200,eps(Float64))
+        end
+    end
 
-# Test the interface for interacting with measurement sets
-let
-    Nant = 10
-    Nfreq = 2
+    @testset "corrupted autos" begin
+        for T in (GainCalibration,PolarizationCalibration)
+            cal = T(Nant,Nfreq)
+            for i in eachindex(cal.jones)
+                cal.jones[i] = rand(eltype(cal.jones))
+            end
+            TTCal.fixphase!(cal,"1x")
+            data  = Array{Complex64,3}(complex(randn(4,Nfreq,Nbase),randn(4,Nfreq,Nbase)))
+            model = copy(data)
+            corrupt!(data,cal,ant1,ant2)
+            α = 1
+            for ant = 1:Nant
+                data[:,:,α] = rand(4,Nfreq)
+                α += Nant-ant+1
+            end
+            test_solve(cal,data,model,200,eps(Float64))
+        end
+    end
 
-    # Run as `gaincal(...)`
-    name,ms = createms(Nant,Nfreq)
-    sources = readsources("sources.json")
-    ms.table["DATA"] = genvis(ms,sources,ConstantBeam())
+    @testset "gaincal" begin
+        # Run as `gaincal(...)`
+        name,ms = createms(Nant,Nfreq)
+        sources = readsources("sources.json")
+        ms.table["DATA"] = genvis(ms,sources,ConstantBeam())
 
-    mycal = gaincal(ms,sources,ConstantBeam(),
-                    maxiter=100,tolerance=eps(Float64))
-    @test !any(mycal.flags)
-    @test vecnorm(mycal.jones - ones(DiagonalJonesMatrix,Nant,Nfreq)) < sqrt(eps(Float64))
-    unlock(ms)
+        mycal = gaincal(ms,sources,ConstantBeam(),maxiter=100,tolerance=eps(Float64))
+        @test !any(mycal.flags)
+        @test vecnorm(mycal.jones - ones(DiagonalJonesMatrix,Nant,Nfreq)) < sqrt(eps(Float64))
+        unlock(ms)
 
-    # Run from `main(...)`
-    output_name = tempname()*".jld"
-    TTCal.main(["gaincal","--input",name,"--output",output_name,"--sources","sources.json","--maxiter","100","--tolerance","$(eps(Float64))","--beam","constant"])
-    mycal = TTCal.read(output_name)
-    @test !any(mycal.flags)
-    @test vecnorm(mycal.jones - ones(DiagonalJonesMatrix,Nant,Nfreq)) < sqrt(eps(Float64))
+        # Run from `main(...)`
+        output_name = tempname()*".jld"
+        TTCal.main(["gaincal","--input",name,"--output",output_name,"--sources","sources.json",
+                    "--maxiter","100","--tolerance","$(eps(Float64))","--beam","constant"])
+        mycal = TTCal.read(output_name)
+        @test !any(mycal.flags)
+        @test vecnorm(mycal.jones - ones(DiagonalJonesMatrix,Nant,Nfreq)) < sqrt(eps(Float64))
+    end
+
+    @testset "polcal" begin
+        # Run as `polcal(...)`
+        name,ms = createms(Nant,Nfreq)
+        sources = readsources("sources.json")
+        ms.table["DATA"] = genvis(ms,sources,ConstantBeam())
+
+        mycal = polcal(ms,sources,ConstantBeam(),maxiter=100,tolerance=eps(Float64))
+        @test !any(mycal.flags)
+        @test vecnorm(mycal.jones - ones(JonesMatrix,Nant,Nfreq)) < sqrt(eps(Float64))
+        unlock(ms)
+
+        # Run from `main(...)`
+        output_name = tempname()*".jld"
+        TTCal.main(["polcal","--input",name,"--output",output_name,"--sources","sources.json",
+                    "--maxiter","100","--tolerance","$(eps(Float64))","--beam","constant"])
+        mycal = TTCal.read(output_name)
+        @test !any(mycal.flags)
+        @test vecnorm(mycal.jones - ones(JonesMatrix,Nant,Nfreq)) < sqrt(eps(Float64))
+    end
 end
 

--- a/test/calibration.jl
+++ b/test/calibration.jl
@@ -109,7 +109,7 @@
         TTCal.solve!(mycal,data,model,flags,ant1,ant2,maxiter,tolerance,false,quiet=true)
         TTCal.fixphase!(mycal,"1x")
         @test !any(mycal.flags)
-        @test vecnorm(mycal.jones-cal.jones) < eps(Float32)
+        @test vecnorm(mycal.jones-cal.jones) < eps(Float32)*vecnorm(cal.jones)
     end
 
     @testset "unity gains" begin

--- a/test/calibration.jl
+++ b/test/calibration.jl
@@ -117,7 +117,7 @@ function test_solve(cal,data,model,
     mycal = similar(cal)
     flags = zeros(Bool,size(data))
     TTCal.solve!(mycal,data,model,flags,
-                 ant1,ant2,maxiter,tolerance)
+                 ant1,ant2,maxiter,tolerance,false)
     TTCal.fixphase!(mycal,"1x")
     @test !any(mycal.flags)
     @test vecnorm(mycal.jones-cal.jones) < eps(Float32)

--- a/test/fitvis.jl
+++ b/test/fitvis.jl
@@ -14,7 +14,7 @@ let
     lold,mold = TTCal.direction_cosines(ms.phase_direction,point.direction)
     az += 0.1 * π/180
     el += 0.1 * π/180
-    dir = Direction(dir"AZEL",Quantity(az,"rad"),Quantity(el,"rad"))
+    dir = Direction(dir"AZEL",az*radians,el*radians)
 
     l,m = fitvis(ms,dir,maxiter = 100, tolerance = sqrt(eps(Float64)))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,10 @@
 using TTCal
-using Base.Test
+if VERSION >= v"0.5-"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 using CasaCore.Measures
 using CasaCore.Tables
 

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -40,31 +40,31 @@ function createms(Nant,Nfreq)
 
     frame = ReferenceFrame()
     pos = observatory("OVRO_MMA")
-    set!(frame,Epoch(epoch"UTC",Quantity(t,"s")))
+    set!(frame,Epoch(epoch"UTC",t*seconds))
     set!(frame,pos)
-    zenith = Direction(dir"AZEL",q"0.0deg",q"90.0deg")
+    zenith = Direction(dir"AZEL",0degrees,90degrees)
     phase_dir = measure(frame,zenith,dir"J2000")
 
     name  = tempname()*".ms"
     table = Table(name)
 
     subtable = Table("$name/SPECTRAL_WINDOW")
-    Tables.addRows!(subtable,1)
+    Tables.addrows!(subtable,1)
     subtable["CHAN_FREQ"] = reshape(ν,length(ν),1)
     unlock(subtable)
 
     subtable = Table("$name/ANTENNA")
-    Tables.addRows!(subtable,Nant)
-    x,y,z = vector(pos)
+    Tables.addrows!(subtable,Nant)
+    x,y,z = pos.x, pos.y, pos.z
     subtable["POSITION"] = [x;y;z]*ones(1,Nant)
     unlock(subtable)
 
     subtable = Table("$name/FIELD")
-    Tables.addRows!(subtable,1)
+    Tables.addrows!(subtable,1)
     subtable["PHASE_DIR"] = reshape([longitude(phase_dir);latitude(phase_dir)],2,1)
     unlock(subtable)
 
-    Tables.addRows!(table,Nbase)
+    Tables.addrows!(table,Nbase)
     table[kw"SPECTRAL_WINDOW"] = "Table: $name/SPECTRAL_WINDOW"
     table[kw"ANTENNA"] = "Table: $name/ANTENNA"
     table[kw"FIELD"] = "Table: $name/FIELD"

--- a/test/sourcemodel.jl
+++ b/test/sourcemodel.jl
@@ -9,9 +9,9 @@ end
 
 let
     frame   = ReferenceFrame()
-    sources = [Source("S1",Point("P1",Direction(dir"AZEL",q"0.0deg",q"+45.0deg"),
+    sources = [Source("S1",Point("P1",Direction(dir"AZEL","0.0deg","+45.0deg"),
                            Spectrum(1.0,2.0,3.0,4.0,10e6,[0.0]))),
-               Source("S2",Point("P2",Direction(dir"AZEL",q"0.0deg",q"-45.0deg"),
+               Source("S2",Point("P2",Direction(dir"AZEL","0.0deg","-45.0deg"),
                            Spectrum(1.0,2.0,3.0,4.0,10e6,[0.0])))]
     @test TTCal.isabovehorizon(frame,sources[1]) == true
     @test TTCal.isabovehorizon(frame,sources[2]) == false
@@ -28,11 +28,7 @@ let
     point = cas_a.components[1]
     @test cas_a.name == "Cas A"
     @test point.name == "Cas A"
-    dir1 = point.direction
-    dir2 = Direction(dir"J2000",q"23h23m24s",q"58d48m54s")
-    @test coordinate_system(dir1) === dir"J2000"
-    @test longitude(dir1) ≈ longitude(dir2)
-    @test  latitude(dir1) ≈  latitude(dir2)
+    @test point.direction == Direction(dir"J2000","23h23m24s","58d48m54s")
     @test point.spectrum.stokes.I == 555904.26
     @test point.spectrum.stokes.Q == 0
     @test point.spectrum.stokes.U == 0
@@ -44,11 +40,7 @@ let
     point = cyg_a.components[1]
     @test cyg_a.name == "Cyg A"
     @test point.name == "Cyg A"
-    dir1 = point.direction
-    dir2 = Direction(dir"J2000",q"19h59m28.35663s",q"+40d44m02.0970s")
-    @test coordinate_system(dir1) === dir"J2000"
-    @test longitude(dir1) ≈ longitude(dir2)
-    @test  latitude(dir1) ≈  latitude(dir2)
+    @test point.direction == Direction(dir"J2000","19h59m28.35663s","+40d44m02.0970s")
     @test point.spectrum.stokes.I == 49545.02
     @test point.spectrum.stokes.Q == 0
     @test point.spectrum.stokes.U == 0
@@ -58,11 +50,11 @@ let
 end
 
 let
-    sources1 = [Source("S1",Point("P1",Direction(dir"J2000",q"1h",q"0d"),
+    sources1 = [Source("S1",Point("P1",Direction(dir"J2000","1h","0d"),
                             Spectrum(1.0,2.0,3.0,4.0,10e6,[0.0]))),
-                Source("S2",Point("P2",Direction(dir"J2000",q"2h",q"0d"),
+                Source("S2",Point("P2",Direction(dir"J2000","2h","0d"),
                             Spectrum(1.0,2.0,3.0,4.0,10e6,[0.0]))),
-                Source("S3",Point("P3",Direction(dir"J2000",q"3h",q"0d"),
+                Source("S3",Point("P3",Direction(dir"J2000","3h","0d"),
                             Spectrum(1.0,2.0,3.0,4.0,10e6,[0.0])))]
 
     filename = tempname()*".json"
@@ -75,11 +67,7 @@ let
         point2  = source2.components[1]
         @test source1.name == source2.name
         @test point1.name == point2.name
-        dir1 = point1.direction
-        dir2 = point2.direction
-        @test coordinate_system(dir1) === coordinate_system(dir2)
-        @test longitude(dir1) ≈ longitude(dir2)
-        @test  latitude(dir1) ≈  latitude(dir2)
+        @test point1.direction == point2.direction
         @test point1.spectrum.stokes.I == point2.spectrum.stokes.I
         @test point1.spectrum.stokes.Q == point2.spectrum.stokes.Q
         @test point1.spectrum.stokes.U == point2.spectrum.stokes.U
@@ -91,10 +79,10 @@ end
 
 let
     frame = ReferenceFrame()
-    t = (2015.-1858.)*365.*24.*60.*60. # a rough, current Julian date (in seconds)
-    set!(frame,Epoch(epoch"UTC",Quantity(t,"s")))
+    t = (2015.-1858.)*365. # a rough, current Julian date
+    set!(frame,Epoch(epoch"UTC",t * days))
     set!(frame,observatory("OVRO_MMA"))
-    phase_dir = Direction(dir"J2000",q"19h59m28.35663s",q"+40d44m02.0970s")
+    phase_dir = Direction(dir"J2000","19h59m28.35663s","+40d44m02.0970s")
 
     for iteration = 1:5
         l = 2rand()-1
@@ -115,14 +103,5 @@ let
     l′,m′ = TTCal.direction_cosines(phase_dir,dir)
     @test l ≈ l′
     @test m ≈ m′
-end
-
-let
-    ra = get(q"0h12m34s","deg")
-    @test TTCal.format_ra(ra) == "0h12m34.0000s"
-    dec = get(q"+0d12m34s","deg")
-    @test TTCal.format_dec(dec) == "+0d12m34.0000s"
-    dec = get(q"-0d12m34s","deg")
-    @test TTCal.format_dec(dec) == "-0d12m34.0000s"
 end
 


### PR DESCRIPTION
this seems to work but might need a little bit of tweaking

**Algorithm description:**

TTCal attempts to choose the gains such that the model visibilities match the measured visibilities as closely as possible. However another (equally valid choice) would have been to choose the gains such that the corrected measured visibilities match the model as closely as possible.

Now imagine you have an antenna that is just picking up noise. TTCal will dial down its gain because it's trying to make the model match the measured data. The antenna will appear to look good because its residuals are small. However, when you invert the gains to correct the measured visibilities, the antenna no longer has small residuals.

So as we're calibrating (minimizing | measured - gain of antenna 1 \* gain of antenna 2 \* model |), we will check | measured / (gain of antenna 1 \* gain of antenna 2) - model | to see if each antenna is an outlier.

One bad antenna however, can trick you into thinking other antennas are also bad. So only flag antennas one at a time.

related to #45 but more tweaks might be necessary
